### PR TITLE
Reduce default delegated auth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Customer admin consent:
 teams auth consent-url --tenant-id <customer-tenant-id-or-domain> --output json
 ```
 
+This prints a Microsoft identity platform v2 admin-consent URL with an explicit
+`scope` parameter for the CLI's default delegated Graph scopes.
+
 For enterprises that require their own app registration, configure BYO mode:
 
 ```toml
@@ -175,6 +178,9 @@ teams auth login
 # Device code flow with OSO's public client app
 teams auth login --device-code
 
+# Channel message reads require a broader Graph scope that often needs admin approval
+teams auth login --device-code --scopes "User.Read ChannelMessage.Read.All offline_access"
+
 # Browser-based login with a customer-owned app
 teams auth login --client-id <client-id> --tenant-id <tenant-id>
 
@@ -203,6 +209,12 @@ teams auth login --client-credentials \
 ```
 
 Tokens are cached in the OS keyring — subsequent commands reuse the session without re-authentication.
+
+Default delegated login asks for chat, channel-send, discovery, user lookup,
+and presence scopes. It intentionally does not request
+`ChannelMessage.Read.All`, because Microsoft marks that delegated scope as
+admin-consent required. Use `--scopes` or a customer-owned app when a workflow
+needs channel message reads.
 
 **Credential resolution order**: CLI flags > environment variables > config file profiles.
 

--- a/docs/auth-implementation-plan.md
+++ b/docs/auth-implementation-plan.md
@@ -135,14 +135,13 @@ Recommended initial delegated scopes:
 - `Team.ReadBasic.All`
 - `Channel.ReadBasic.All`
 - `ChannelMessage.Send`
-- `ChannelMessage.Read.All`
 - `Chat.ReadWrite`
 - `ChatMessage.Send`
 - `ChatMessage.Read`
 - `User.ReadBasic.All`
 - `Presence.Read.All`
 
-Implementation note: split these into documented scope presets before release. The current default scope string is broad and convenient for testing, but commercial onboarding should explain exactly why each scope exists and allow lower-scope profiles where possible.
+Implementation note: keep the default scope string below known admin-consent-required delegated scopes where possible. `ChannelMessage.Read.All` is needed for channel message reads, but it should be requested explicitly with `--scopes` or through a customer-owned app because Microsoft marks it as admin-consent required.
 
 ### 2. Customer BYO Public Client App
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -61,8 +61,12 @@ teams auth consent-url --tenant-id <tenant-id-or-domain> --output json
 For the default app, this prints a URL like:
 
 ```text
-https://login.microsoftonline.com/<tenant>/adminconsent?client_id=fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595
+https://login.microsoftonline.com/<tenant>/v2.0/adminconsent?client_id=fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595&scope=...&redirect_uri=...
 ```
+
+The `scope` parameter is explicit so admin consent matches the CLI's default
+delegated Graph scopes instead of every static permission configured on the app
+registration.
 
 Use a concrete tenant ID or verified tenant domain for customer onboarding. `organizations` is useful for sign-in discovery, but a customer admin consent link should normally target the customer's tenant explicitly.
 
@@ -76,7 +80,6 @@ offline_access
 Team.ReadBasic.All
 Channel.ReadBasic.All
 ChannelMessage.Send
-ChannelMessage.Read.All
 Chat.ReadWrite
 ChatMessage.Send
 ChatMessage.Read
@@ -84,7 +87,13 @@ User.ReadBasic.All
 Presence.Read.All
 ```
 
-These permissions cover the current read/write message, team/channel discovery, chat, user lookup, and presence smoke tests. Future features may need additional consent.
+These permissions cover the current chat read/write, channel-send, team/channel discovery, user lookup, and presence smoke tests. The default does not include `ChannelMessage.Read.All` because Microsoft marks that delegated Graph scope as admin-consent required. Add it explicitly when a workflow needs channel message reads:
+
+```bash
+teams auth login --device-code --scopes "User.Read ChannelMessage.Read.All offline_access"
+```
+
+Future features may need additional consent.
 
 ## Login options
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,7 +44,6 @@ offline_access
 Team.ReadBasic.All
 Channel.ReadBasic.All
 ChannelMessage.Send
-ChannelMessage.Read.All
 Chat.ReadWrite
 ChatMessage.Send
 ChatMessage.Read
@@ -52,7 +51,7 @@ User.ReadBasic.All
 Presence.Read.All
 ```
 
-Customers should review these during admin consent. Future features may require additional permissions.
+The default avoids `ChannelMessage.Read.All` because Microsoft marks that delegated Graph scope as admin-consent required. Customers that need channel message reads should grant it explicitly with `--scopes` or through a customer-owned app. Future features may require additional permissions.
 
 ## Why did `team list` return no teams?
 

--- a/src/auth/auth_code_pkce.rs
+++ b/src/auth/auth_code_pkce.rs
@@ -8,10 +8,8 @@ use std::sync::Mutex;
 use tokio::sync::oneshot;
 
 use super::token::MsTokenResponse;
+use crate::config::{DEFAULT_DELEGATED_SCOPES, DEFAULT_REDIRECT_URI};
 use crate::error::{Result, TeamsError};
-
-const DEFAULT_SCOPES: &str = "User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Send ChannelMessage.Read.All Chat.ReadWrite ChatMessage.Send ChatMessage.Read User.ReadBasic.All Presence.Read.All offline_access";
-const REDIRECT_URI: &str = "http://localhost:8400/callback";
 
 fn random_urlsafe_bytes(len: usize) -> Result<String> {
     let mut bytes = vec![0u8; len];
@@ -37,7 +35,7 @@ pub async fn authenticate(
     tenant_id: &str,
     scopes: Option<&str>,
 ) -> Result<MsTokenResponse> {
-    let scopes = scopes.unwrap_or(DEFAULT_SCOPES);
+    let scopes = scopes.unwrap_or(DEFAULT_DELEGATED_SCOPES);
     let (verifier, challenge) = generate_pkce()?;
 
     let state = random_urlsafe_bytes(16)?;
@@ -51,7 +49,7 @@ pub async fn authenticate(
          &state={state}\
          &code_challenge={challenge}\
          &code_challenge_method=S256",
-        urlencoding::encode(REDIRECT_URI),
+        urlencoding::encode(DEFAULT_REDIRECT_URI),
         urlencoding::encode(scopes),
     );
 
@@ -150,7 +148,7 @@ pub async fn authenticate(
             ("grant_type", "authorization_code"),
             ("client_id", client_id),
             ("code", &code),
-            ("redirect_uri", REDIRECT_URI),
+            ("redirect_uri", DEFAULT_REDIRECT_URI),
             ("code_verifier", &verifier),
             ("scope", scopes),
         ])

--- a/src/auth/device_code.rs
+++ b/src/auth/device_code.rs
@@ -3,9 +3,8 @@ use serde::Deserialize;
 use std::time::Duration;
 
 use super::token::MsTokenResponse;
+use crate::config::DEFAULT_DELEGATED_SCOPES;
 use crate::error::{Result, TeamsError};
-
-const DEFAULT_SCOPES: &str = "User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Send ChannelMessage.Read.All Chat.ReadWrite ChatMessage.Send ChatMessage.Read User.ReadBasic.All Presence.Read.All offline_access";
 
 #[derive(Debug, Deserialize)]
 struct DeviceCodeResponse {
@@ -40,7 +39,7 @@ pub async fn authenticate(
     tenant_id: &str,
     scopes: Option<&str>,
 ) -> Result<MsTokenResponse> {
-    let scopes = scopes.unwrap_or(DEFAULT_SCOPES);
+    let scopes = scopes.unwrap_or(DEFAULT_DELEGATED_SCOPES);
     let http = Client::new();
 
     // Step 1: Request device code

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -110,6 +110,31 @@ fn token_warnings(claims: Option<&auth::token::TokenClaims>) -> Vec<String> {
     warnings
 }
 
+fn graph_admin_consent_scopes(scopes: &str) -> String {
+    scopes
+        .split_whitespace()
+        .map(|scope| {
+            if scope.starts_with("https://")
+                || matches!(scope, "openid" | "profile" | "email" | "offline_access")
+            {
+                scope.to_string()
+            } else {
+                format!("https://graph.microsoft.com/{scope}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn delegated_admin_consent_url(client_id: &str, tenant_id: &str) -> String {
+    let scopes = graph_admin_consent_scopes(config::DEFAULT_DELEGATED_SCOPES);
+    format!(
+        "https://login.microsoftonline.com/{tenant_id}/v2.0/adminconsent?client_id={client_id}&scope={}&redirect_uri={}",
+        urlencoding::encode(&scopes),
+        urlencoding::encode(config::DEFAULT_REDIRECT_URI)
+    )
+}
+
 pub async fn run(
     cmd: AuthCommand,
     config: &ConfigFile,
@@ -190,13 +215,13 @@ pub async fn run(
                 config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
             let tenant_id =
                 config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-            let url = format!(
-                "https://login.microsoftonline.com/{tenant_id}/adminconsent?client_id={client_id}"
-            );
+            let url = delegated_admin_consent_url(&client_id, &tenant_id);
             let msg = serde_json::json!({
                 "admin_consent_url": url,
                 "client_id": client_id,
                 "tenant_id": tenant_id,
+                "scope": config::DEFAULT_DELEGATED_SCOPES,
+                "redirect_uri": config::DEFAULT_REDIRECT_URI,
             });
             output::print_success(format, &msg, start);
             Ok(())
@@ -220,12 +245,15 @@ pub async fn run(
             let token = auth::resolve_token(profile).ok();
             let claims = token.as_ref().and_then(|t| t.unverified_claims());
             let warnings = token_warnings(claims.as_ref());
+            let admin_consent_url = delegated_admin_consent_url(&client_id, &tenant_id);
             let msg = serde_json::json!({
                 "profile": profile,
                 "auth_app": auth_app,
                 "client_id": client_id,
                 "tenant_id": tenant_id,
-                "admin_consent_url": format!("https://login.microsoftonline.com/{tenant_id}/adminconsent?client_id={client_id}"),
+                "admin_consent_url": admin_consent_url,
+                "default_delegated_scopes": config::DEFAULT_DELEGATED_SCOPES,
+                "redirect_uri": config::DEFAULT_REDIRECT_URI,
                 "authenticated": token.is_some(),
                 "warnings": warnings,
                 "token": token.as_ref().map(|t| serde_json::json!({

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use crate::error::{Result, TeamsError};
 
 pub const OSO_PUBLIC_CLIENT_ID: &str = "fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595";
 pub const DEFAULT_DELEGATED_TENANT_ID: &str = "organizations";
+pub const DEFAULT_DELEGATED_SCOPES: &str = "User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Send Chat.ReadWrite ChatMessage.Send ChatMessage.Read User.ReadBasic.All Presence.Read.All offline_access";
+pub const DEFAULT_REDIRECT_URI: &str = "http://localhost:8400/callback";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigFile {
@@ -402,6 +404,13 @@ auth_flow = "device-code"
             resolve_delegated_tenant_id(None, "default", &config),
             DEFAULT_DELEGATED_TENANT_ID
         );
+    }
+
+    #[test]
+    fn default_delegated_scopes_avoid_admin_required_channel_read() {
+        assert!(DEFAULT_DELEGATED_SCOPES.contains("ChatMessage.Send"));
+        assert!(DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Send"));
+        assert!(!DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Read.All"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -64,8 +64,12 @@ fn auth_consent_url_uses_oso_default_client_id() {
         .success()
         .stdout(
             predicate::str::contains("fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595")
-                .and(predicate::str::contains("adminconsent"))
-                .and(predicate::str::contains("organizations")),
+                .and(predicate::str::contains("v2.0/adminconsent"))
+                .and(predicate::str::contains("scope="))
+                .and(predicate::str::contains("redirect_uri="))
+                .and(predicate::str::contains("ChatMessage.Send"))
+                .and(predicate::str::contains("organizations"))
+                .and(predicate::str::contains("ChannelMessage.Read.All").not()),
         );
 }
 


### PR DESCRIPTION
## Summary
- remove ChannelMessage.Read.All from the default delegated login scope bundle
- centralize the default delegated scope string across browser PKCE and device-code auth
- change auth consent-url/auth doctor to emit a v2 admin-consent URL with explicit default scopes and redirect URI
- document that channel message reads require an explicit broader scope/admin-consent path

## Context
Follow-up from issue #10 after the reporter confirmed their blocker is the Microsoft admin approval screen. The default should avoid known admin-consent-required delegated scopes where possible so direct/group chat read-send and channel send have a lower-friction path.

The explicit v2 consent URL matters because Microsoft static admin consent can show every permission configured on the app registration. The CLI should request the same reduced default scopes at consent time.

## Verification
- cargo fmt
- cargo test