### PR TITLE
Release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.4 - 2026-06-04
+
+### Changed
+
+- Reduced the default delegated Graph login scopes by removing `ChannelMessage.Read.All`.
+- Updated `auth consent-url` and `auth doctor` to emit Microsoft identity platform v2 admin consent URLs with explicit scopes and redirect URI diagnostics.
+- Documented the channel-message read consent path separately from the default chat/message send workflow.
+
 ## v0.2.3 - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -39,7 +39,7 @@ fn version_flag_works() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("0.2.3"));
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- bump teams-cli to v0.2.4
- add changelog notes for the lower default auth scopes and v2 admin consent diagnostics
- make the version CLI test follow the package version

## Verification
- cargo test
- git diff --check

## Release path
Merging this PR changes Cargo.toml on main, which triggers .github/workflows/auto-tag.yml. That workflow creates tag v0.2.4, and the tag push triggers .github/workflows/release.yml to build release artifacts, publish the GitHub Release, and dispatch the Homebrew tap update.