### PR TITLE
Harden GitHub Actions release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,9 +10,9 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,23 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check --all-targets
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt
@@ -40,12 +44,14 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets -- -D warnings
 
   test:
@@ -55,9 +61,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -34,14 +34,16 @@ jobs:
             runner: windows-latest
             archive: zip
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
 
@@ -93,7 +95,7 @@ jobs:
           Compress-Archive -Path "dist/$package" -DestinationPath "$package.zip"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: teams-${{ matrix.target }}
           path: teams-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -102,11 +104,15 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
@@ -118,7 +124,7 @@ jobs:
           cat checksums-sha256.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: |
@@ -129,9 +135,10 @@ jobs:
     name: Update Homebrew Tap
     needs: release
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Update homebrew formula
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           repository: osodevops/homebrew-tap

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -56,6 +56,44 @@ Required:
 - GitHub Actions passes on Linux, macOS, and Windows.
 - Release workflow builds artifacts for supported platforms.
 
+## Release automation checklist
+
+The full release path is version-bump driven, not PR-merge driven:
+
+1. Open a release PR that updates `Cargo.toml` to the next version.
+2. Keep `Cargo.lock` aligned for the root `teams-cli` package version.
+3. Add a matching `CHANGELOG.md` entry.
+4. After the PR is merged to `main`, confirm `.github/workflows/auto-tag.yml` runs successfully.
+5. Confirm `auto-tag.yml` creates the `vX.Y.Z` tag.
+6. Confirm the tag starts `.github/workflows/release.yml`.
+7. Confirm the release workflow completes all build targets, creates checksums, publishes the GitHub Release, and runs the Homebrew tap update job.
+
+Important details:
+
+- Merging a feature PR that does not change `Cargo.toml` only runs CI on `main`; it does not create a release.
+- `auto-tag.yml` is path-filtered to `Cargo.toml` and only tags when the package version changes.
+- The tag push is what triggers `release.yml`.
+- The release workflow currently builds:
+  - `x86_64-apple-darwin`
+  - `aarch64-apple-darwin`
+  - `x86_64-unknown-linux-musl`
+  - `aarch64-unknown-linux-musl`
+  - `x86_64-pc-windows-msvc`
+
+Homebrew tap follow-up as of 2026-06-04:
+
+- `release.yml` sends a `repository_dispatch` event to `osodevops/homebrew-tap`.
+- The tap repository currently has no workflow listening for that dispatch event.
+- Until that automation exists, update `osodevops/homebrew-tap` manually after each CLI release.
+- Use the published `checksums-sha256.txt` from the GitHub Release to update `Formula/teams-cli.rb`.
+- Verify the remote formula points at the new release URLs and checksums.
+
+Known CI maintenance item as of 2026-06-04:
+
+- GitHub Actions is warning that Node.js 20 actions are deprecated.
+- Update pinned actions used by CI/release before GitHub's June 16, 2026 Node 24 default switch.
+- Watch especially `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, and `softprops/action-gh-release`.
+
 ## Commercial release blockers
 
 These must be resolved before marketing this as production-ready for external customers:

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -94,6 +94,27 @@ Known CI maintenance item as of 2026-06-04:
 - Update pinned actions used by CI/release before GitHub's June 16, 2026 Node 24 default switch.
 - Watch especially `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, and `softprops/action-gh-release`.
 
+## GitHub Actions supply-chain checklist
+
+For every GitHub Actions dependency update:
+
+1. Verify the owner and repository are unchanged.
+2. Verify the target tag exists in the official action repository.
+3. Resolve the tag to the underlying commit.
+4. Pin the workflow to the full 40-character commit SHA, not the tag.
+5. Keep the trailing version comment accurate, for example `# v7.0.1`.
+6. Check `action.yml` for the runtime. Prefer Node 24 compatible action versions.
+7. Read the release notes for behavior changes, new inputs, permission changes, or token handling changes.
+8. Keep workflow `permissions` at least privilege. Do not give write permissions to build/test jobs.
+9. Set `persist-credentials: false` on `actions/checkout` unless a later step explicitly needs checkout's persisted git credentials.
+10. Do not merge a Dependabot Actions PR if it changes the action owner/repository, points to a fork, removes SHA pinning, or leaves comments inconsistent with the reviewed version.
+
+Preferred repository setting:
+
+- Require actions and reusable workflows to be pinned to a full-length commit SHA at the repository or organization level.
+
+Dependabot is configured to group GitHub Actions updates into one PR so the complete workflow supply-chain diff can be reviewed together.
+
 ## Commercial release blockers
 
 These must be resolved before marketing this as production-ready for external customers:


### PR DESCRIPTION
## Summary
- document the version-bump release path and Homebrew tap follow-up gap
- update GitHub Actions dependencies to reviewed official Node 24 compatible SHAs
- keep all action refs pinned to full 40-character commit SHAs with accurate version comments
- reduce workflow token permissions and disable persisted checkout credentials where not needed
- group future Dependabot GitHub Actions updates into one reviewable PR
- add a release-guide checklist for future Actions supply-chain reviews

## Reviewed action targets
- actions/checkout v6.0.3 -> df4cb1c069e1874edd31b4311f1884172cec0e10
- actions/upload-artifact v7.0.1 -> 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
- actions/download-artifact v8.0.1 -> 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
- softprops/action-gh-release v3.0.0 -> b4309332981a82ec1c5618f44dd2e27cc8bfbfda
- peter-evans/repository-dispatch v4.0.1 -> 28959ce8df70de7be546dd1250a005dd32156697
- Swatinem/rust-cache v2.9.1 -> c19371144df3bb44fab255c43d04cbc2ab54d1c4
- dtolnay/rust-toolchain stable branch -> 29eef336d9b2848a0b548edc03f92a220660cdb8

## Verification
- ruby YAML parse for all workflow/dependabot YAML files
- actionlint
- git diff --check
- custom full-SHA pin scan across .github/workflows/*.yml

This supersedes the individual Dependabot GitHub Actions PRs #1, #2, #3, #4, and #9.