### PR TITLE
Refresh expired access tokens using the stored refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Automatic refresh-token redemption. When the stored access token is expired (or within a short skew window of expiring), the CLI now silently exchanges the persisted `refresh_token` for a fresh access token via the OAuth2 `refresh_token` grant and updates the keyring, instead of failing with `AUTH_TOKEN_EXPIRED` roughly an hour after login. The previous re-login behaviour remains as a fallback when no refresh token is stored or the refresh request is rejected. This resolves the standing "automatic refresh-token handling" known limitation (#16).
+
 ## v0.2.4 - 2026-06-04
 
 ### Changed

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -194,7 +194,7 @@ Tokens are stored in the operating system keyring:
 
 The config file stores profile settings, not access tokens.
 
-Current known gap: automatic refresh-token handling is not yet release-grade. If a token expires and refresh does not happen, commands return `AUTH_TOKEN_EXPIRED` and the user must run `teams auth login` again.
+The CLI automatically redeems the stored refresh token when an access token is expired or near expiry, then updates the keyring with the refreshed token. If no refresh token is stored, or the identity platform rejects the refresh request, commands return `AUTH_TOKEN_EXPIRED` and the user must run `teams auth login` again.
 
 ## Diagnostics
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,7 +63,7 @@ Teams/Graph can list chats that later fail message reads because the user is no 
 
 ## Why did I get `AUTH_TOKEN_EXPIRED`?
 
-The stored access token expired. The CLI requests `offline_access`, but automatic refresh-token handling is still a release-readiness gap. Run:
+The CLI automatically refreshes an expired access token using the stored refresh token (login requests `offline_access`), so this should be rare. You will still see `AUTH_TOKEN_EXPIRED` when no refresh token is stored or the refresh is rejected — for example the refresh token itself expired or was revoked. In that case, re-authenticate:
 
 ```bash
 teams auth login --device-code

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -122,8 +122,9 @@ Tenant ID or tenant domain.
 Test-only switch used to avoid OS keyring access in automated tests. Do not use
 for real login sessions.
 .SH KNOWN GAPS
-Automatic refresh-token handling must be completed and validated before public
-commercial release. If a stored access token expires today, run:
+Stored access tokens are refreshed automatically when a refresh token is
+available. If the refresh token is missing, expired, revoked, or rejected by
+the identity platform, run:
 .PP
 .nf
 teams auth login --device-code

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -29,7 +29,7 @@ Live read-only validation passed against the OSO profile:
 Known live behavior:
 
 - Some meeting chats can appear in `chat list` but reject message reads with `403` if the user is no longer in the roster.
-- Stored token expiry currently requires manual re-login.
+- Stored token expiry is handled through refresh-token redemption when a refresh token is available. `AUTH_TOKEN_EXPIRED` still means the refresh token is missing, expired, revoked, or rejected by the identity platform.
 
 Entra app registration status as of 2026-05-27:
 
@@ -120,15 +120,14 @@ Dependabot is configured to group GitHub Actions updates into one PR so the comp
 These must be resolved before marketing this as production-ready for external customers:
 
 1. Publisher verification for the OSO Entra app.
-2. Automatic refresh-token handling and tests.
-3. Windows live validation using Windows Credential Manager.
-4. Controlled write/read smoke test in a dedicated Teams test channel.
-5. Documented admin-consent onboarding flow for customer tenants.
-6. Clear policy for unsupported Graph operations, tenant restrictions, and destructive commands.
-7. Security review of token storage, logs, and exported token behavior.
-8. Versioned release notes and upgrade guidance.
-9. Public website HTTPS fixed for `https://msteamscli.com/`; HTTP is live, but the current TLS certificate does not cover the hostname.
-10. Terms of service URL published and added to the Entra app branding.
+2. Windows live validation using Windows Credential Manager.
+3. Controlled write/read smoke test in a dedicated Teams test channel.
+4. Documented admin-consent onboarding flow for customer tenants.
+5. Clear policy for unsupported Graph operations, tenant restrictions, and destructive commands.
+6. Security review of token storage, logs, and exported token behavior.
+7. Versioned release notes and upgrade guidance.
+8. Public website HTTPS fixed for `https://msteamscli.com/`; HTTP is live, but the current TLS certificate does not cover the hostname.
+9. Terms of service URL published and added to the Entra app branding.
 
 ## Microsoft official trust checklist
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,15 +18,15 @@ RUST_LOG=teams=debug teams chat list --output json
 
 ## `AUTH_TOKEN_EXPIRED`
 
-Meaning: the keyring token is expired.
+Meaning: the keyring access token is expired and could not be refreshed automatically.
 
-Current workaround:
+The CLI now silently redeems the stored refresh token when the access token is expired or about to expire, so this error normally only appears when no refresh token is stored or the refresh request is rejected (for example the refresh token expired or was revoked).
+
+Resolution:
 
 ```bash
 teams auth login --device-code
 ```
-
-Release-readiness note: automatic refresh-token handling still needs to be completed and validated.
 
 ## `AUTH_FAILED` or login fails
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,16 +2,25 @@ pub mod auth_code_pkce;
 pub mod client_credentials;
 pub mod device_code;
 pub mod keyring;
+pub mod refresh;
 pub mod token;
 
+use chrono::{Duration, Utc};
+
+use crate::config::DEFAULT_DELEGATED_SCOPES;
 use crate::error::{Result, TeamsError};
 use token::TokenInfo;
 
+/// Refresh slightly ahead of the hard expiry so a token does not lapse
+/// mid-request.
+const EXPIRY_SKEW_SECS: i64 = 60;
+
 /// Resolve an access token using the priority chain:
-/// 1. TEAMS_CLI_ACCESS_TOKEN env var
-/// 2. Keyring (stored token, check expiry)
+/// 1. TEAMS_CLI_ACCESS_TOKEN env var (used verbatim, never refreshed)
+/// 2. Keyring: if the stored token is (near) expired, silently redeem its
+///    refresh token; otherwise return it as-is
 /// 3. Error
-pub fn resolve_token(profile: &str) -> Result<TokenInfo> {
+pub async fn resolve_token(profile: &str) -> Result<TokenInfo> {
     // 1. Direct env var override
     if let Ok(token) = std::env::var("TEAMS_CLI_ACCESS_TOKEN") {
         return Ok(TokenInfo {
@@ -27,15 +36,80 @@ pub fn resolve_token(profile: &str) -> Result<TokenInfo> {
     // 2. Keyring
     match keyring::get_token(profile) {
         Ok(info) => {
-            if info.is_expired() {
-                Err(TeamsError::TokenExpired)
-            } else {
-                Ok(info)
+            if !needs_refresh(&info) {
+                return Ok(info);
+            }
+            // Token is at/near expiry: attempt a silent refresh-token
+            // redemption. Any failure falls back to the original behaviour
+            // (TokenExpired) so the observable exit code is unchanged.
+            match attempt_refresh(profile, &info).await {
+                Ok(refreshed) => Ok(refreshed),
+                Err(e) => {
+                    tracing::debug!("Silent token refresh failed, treating as expired: {e}");
+                    Err(TeamsError::TokenExpired)
+                }
             }
         }
         Err(_) => Err(TeamsError::AuthError(
             "Not authenticated. Run `teams auth login` first.".into(),
         )),
+    }
+}
+
+/// Whether the token should be refreshed: already expired, or within the skew
+/// window of expiry. Tokens with no expiry information are assumed valid.
+fn needs_refresh(info: &TokenInfo) -> bool {
+    info.is_expired()
+        || matches!(
+            info.expires_at,
+            Some(expires) if Utc::now() + Duration::seconds(EXPIRY_SKEW_SECS) >= expires
+        )
+}
+
+/// Silently redeem the stored refresh token for a fresh access token and persist
+/// it. Returns an error (mapped to `TokenExpired` by the caller) when the token
+/// cannot be refreshed — e.g. no refresh token, undecodable claims, or the
+/// identity platform rejecting the request.
+async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
+    let refresh_token = info
+        .refresh_token
+        .as_deref()
+        .ok_or(TeamsError::TokenExpired)?;
+
+    // The expired JWT still decodes (decoding ignores expiry); recover the
+    // tenant + client id originally authenticated with from its claims.
+    let claims = info.unverified_claims().ok_or(TeamsError::TokenExpired)?;
+    let tenant_id = claims.tid.ok_or(TeamsError::TokenExpired)?;
+    let client_id = claims
+        .azp
+        .or(claims.appid)
+        .ok_or(TeamsError::TokenExpired)?;
+
+    let scope = refresh_scope(info.scope.as_deref());
+
+    let response =
+        refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, &scope).await?;
+    let refreshed = response.into_token_info(profile);
+
+    // Best-effort persistence so the next invocation reuses the new token.
+    let _ = keyring::store_token(profile, &refreshed);
+
+    Ok(refreshed)
+}
+
+/// Build the scope string for the refresh request: reuse the originally granted
+/// scope (ensuring `offline_access` so future refreshes keep working), or fall
+/// back to the default delegated scopes.
+fn refresh_scope(existing: Option<&str>) -> String {
+    match existing {
+        Some(scope) if !scope.trim().is_empty() => {
+            if scope.split_whitespace().any(|s| s == "offline_access") {
+                scope.to_string()
+            } else {
+                format!("{scope} offline_access")
+            }
+        }
+        _ => DEFAULT_DELEGATED_SCOPES.to_string(),
     }
 }
 
@@ -49,4 +123,93 @@ pub fn require_delegated_token(token: &TokenInfo, operation: &str) -> Result<()>
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token_with(
+        expires_at: Option<chrono::DateTime<Utc>>,
+        refresh_token: Option<&str>,
+        scope: Option<&str>,
+    ) -> TokenInfo {
+        TokenInfo {
+            access_token: "not-a-jwt".into(),
+            expires_at,
+            token_type: "Bearer".into(),
+            scope: scope.map(|s| s.to_string()),
+            refresh_token: refresh_token.map(|s| s.to_string()),
+            profile: "default".into(),
+        }
+    }
+
+    #[test]
+    fn needs_refresh_true_when_expired() {
+        let info = token_with(Some(Utc::now() - Duration::hours(1)), None, None);
+        assert!(needs_refresh(&info));
+    }
+
+    #[test]
+    fn needs_refresh_true_within_skew_window() {
+        // Expires in 30s, which is inside the 60s skew window.
+        let info = token_with(Some(Utc::now() + Duration::seconds(30)), None, None);
+        assert!(needs_refresh(&info));
+    }
+
+    #[test]
+    fn needs_refresh_false_when_well_in_future() {
+        let info = token_with(Some(Utc::now() + Duration::hours(1)), None, None);
+        assert!(!needs_refresh(&info));
+    }
+
+    #[test]
+    fn needs_refresh_false_without_expiry() {
+        let info = token_with(None, None, None);
+        assert!(!needs_refresh(&info));
+    }
+
+    #[test]
+    fn refresh_scope_falls_back_to_defaults_when_absent() {
+        assert_eq!(refresh_scope(None), DEFAULT_DELEGATED_SCOPES);
+        assert_eq!(refresh_scope(Some("   ")), DEFAULT_DELEGATED_SCOPES);
+    }
+
+    #[test]
+    fn refresh_scope_appends_offline_access_when_missing() {
+        assert_eq!(
+            refresh_scope(Some("User.Read Chat.ReadWrite")),
+            "User.Read Chat.ReadWrite offline_access"
+        );
+    }
+
+    #[test]
+    fn refresh_scope_preserves_existing_offline_access() {
+        assert_eq!(
+            refresh_scope(Some("User.Read offline_access")),
+            "User.Read offline_access"
+        );
+    }
+
+    #[tokio::test]
+    async fn attempt_refresh_without_refresh_token_is_token_expired() {
+        // Expired token, no refresh token: must fail fast as TokenExpired with
+        // no network call.
+        let info = token_with(Some(Utc::now() - Duration::hours(1)), None, None);
+        let err = attempt_refresh("default", &info).await.unwrap_err();
+        assert!(matches!(err, TeamsError::TokenExpired));
+    }
+
+    #[tokio::test]
+    async fn attempt_refresh_with_undecodable_claims_is_token_expired() {
+        // Has a refresh token, but the access token is not a decodable JWT so we
+        // cannot recover tenant/client id: must fail fast as TokenExpired.
+        let info = token_with(
+            Some(Utc::now() - Duration::hours(1)),
+            Some("a-refresh-token"),
+            None,
+        );
+        let err = attempt_refresh("default", &info).await.unwrap_err();
+        assert!(matches!(err, TeamsError::TokenExpired));
+    }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -40,14 +40,12 @@ pub async fn resolve_token(profile: &str) -> Result<TokenInfo> {
                 return Ok(info);
             }
             // Token is at/near expiry: attempt a silent refresh-token
-            // redemption. Any failure falls back to the original behaviour
-            // (TokenExpired) so the observable exit code is unchanged.
+            // redemption. If the token is still inside the skew window, keep
+            // using it on refresh failure; only hard-expired tokens become
+            // TokenExpired.
             match attempt_refresh(profile, &info).await {
                 Ok(refreshed) => Ok(refreshed),
-                Err(e) => {
-                    tracing::debug!("Silent token refresh failed, treating as expired: {e}");
-                    Err(TeamsError::TokenExpired)
-                }
+                Err(e) => handle_refresh_failure(&info, e),
             }
         }
         Err(_) => Err(TeamsError::AuthError(
@@ -64,6 +62,16 @@ fn needs_refresh(info: &TokenInfo) -> bool {
             info.expires_at,
             Some(expires) if Utc::now() + Duration::seconds(EXPIRY_SKEW_SECS) >= expires
         )
+}
+
+fn handle_refresh_failure(info: &TokenInfo, error: TeamsError) -> Result<TokenInfo> {
+    if info.is_expired() {
+        tracing::debug!("Silent token refresh failed for expired token: {error}");
+        Err(TeamsError::TokenExpired)
+    } else {
+        tracing::debug!("Silent token refresh failed before expiry, using current token: {error}");
+        Ok(info.clone())
+    }
 }
 
 /// Silently redeem the stored refresh token for a fresh access token and persist
@@ -89,12 +97,30 @@ async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
 
     let response =
         refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, &scope).await?;
-    let refreshed = response.into_token_info(profile);
+    let refreshed = refreshed_token_info(profile, info, response);
 
     // Best-effort persistence so the next invocation reuses the new token.
     let _ = keyring::store_token(profile, &refreshed);
 
     Ok(refreshed)
+}
+
+fn refreshed_token_info(
+    profile: &str,
+    previous: &TokenInfo,
+    response: token::MsTokenResponse,
+) -> TokenInfo {
+    let mut refreshed = response.into_token_info(profile);
+
+    if refreshed.refresh_token.is_none() {
+        refreshed.refresh_token.clone_from(&previous.refresh_token);
+    }
+
+    if refreshed.scope.is_none() {
+        refreshed.scope.clone_from(&previous.scope);
+    }
+
+    refreshed
 }
 
 /// Build the scope string for the refresh request: reuse the originally granted
@@ -189,6 +215,83 @@ mod tests {
             refresh_scope(Some("User.Read offline_access")),
             "User.Read offline_access"
         );
+    }
+
+    #[test]
+    fn refresh_failure_returns_current_token_inside_skew_window() {
+        let info = token_with(
+            Some(Utc::now() + Duration::seconds(30)),
+            Some("a-refresh-token"),
+            Some("User.Read offline_access"),
+        );
+
+        let resolved =
+            handle_refresh_failure(&info, TeamsError::AuthError("temporary failure".into()))
+                .unwrap();
+
+        assert_eq!(resolved.access_token, info.access_token);
+        assert_eq!(resolved.refresh_token, info.refresh_token);
+    }
+
+    #[test]
+    fn refresh_failure_expires_hard_expired_token() {
+        let info = token_with(
+            Some(Utc::now() - Duration::seconds(1)),
+            Some("a-refresh-token"),
+            Some("User.Read offline_access"),
+        );
+
+        let err =
+            handle_refresh_failure(&info, TeamsError::AuthError("rejected".into())).unwrap_err();
+
+        assert!(matches!(err, TeamsError::TokenExpired));
+    }
+
+    #[test]
+    fn refreshed_token_info_preserves_previous_refresh_token_and_scope_when_missing() {
+        let previous = token_with(
+            Some(Utc::now() - Duration::hours(1)),
+            Some("old-refresh"),
+            Some("User.Read offline_access"),
+        );
+        let response = token::MsTokenResponse {
+            access_token: "new-access".into(),
+            token_type: "Bearer".into(),
+            expires_in: 3600,
+            scope: None,
+            refresh_token: None,
+        };
+
+        let refreshed = refreshed_token_info("work", &previous, response);
+
+        assert_eq!(refreshed.access_token, "new-access");
+        assert_eq!(refreshed.profile, "work");
+        assert_eq!(refreshed.scope.as_deref(), Some("User.Read offline_access"));
+        assert_eq!(refreshed.refresh_token.as_deref(), Some("old-refresh"));
+    }
+
+    #[test]
+    fn refreshed_token_info_uses_rotated_refresh_token_and_scope_when_present() {
+        let previous = token_with(
+            Some(Utc::now() - Duration::hours(1)),
+            Some("old-refresh"),
+            Some("User.Read offline_access"),
+        );
+        let response = token::MsTokenResponse {
+            access_token: "new-access".into(),
+            token_type: "Bearer".into(),
+            expires_in: 3600,
+            scope: Some("User.Read Chat.ReadWrite offline_access".into()),
+            refresh_token: Some("new-refresh".into()),
+        };
+
+        let refreshed = refreshed_token_info("work", &previous, response);
+
+        assert_eq!(
+            refreshed.scope.as_deref(),
+            Some("User.Read Chat.ReadWrite offline_access")
+        );
+        assert_eq!(refreshed.refresh_token.as_deref(), Some("new-refresh"));
     }
 
     #[tokio::test]

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -1,0 +1,43 @@
+use reqwest::Client;
+
+use super::token::MsTokenResponse;
+use crate::error::{Result, TeamsError};
+
+/// Redeem a stored refresh token for a fresh access token using the OAuth2
+/// `refresh_token` grant against the Microsoft identity platform.
+///
+/// Mirrors the error handling of [`super::device_code::authenticate`]: network
+/// failures surface as [`TeamsError::NetworkError`], non-2xx responses and parse
+/// failures as [`TeamsError::AuthError`].
+pub async fn refresh_access_token(
+    client_id: &str,
+    tenant_id: &str,
+    refresh_token: &str,
+    scope: &str,
+) -> Result<MsTokenResponse> {
+    let token_url = format!("https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token");
+    let http = Client::new();
+
+    let resp = http
+        .post(&token_url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", client_id),
+            ("refresh_token", refresh_token),
+            ("scope", scope),
+        ])
+        .send()
+        .await
+        .map_err(TeamsError::NetworkError)?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(TeamsError::AuthError(format!(
+            "Token refresh failed: {body}"
+        )));
+    }
+
+    resp.json::<MsTokenResponse>()
+        .await
+        .map_err(|e| TeamsError::AuthError(format!("Failed to parse refresh response: {e}")))
+}

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -16,10 +16,19 @@ pub async fn refresh_access_token(
     scope: &str,
 ) -> Result<MsTokenResponse> {
     let token_url = format!("https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token");
+    refresh_access_token_at(&token_url, client_id, refresh_token, scope).await
+}
+
+async fn refresh_access_token_at(
+    token_url: &str,
+    client_id: &str,
+    refresh_token: &str,
+    scope: &str,
+) -> Result<MsTokenResponse> {
     let http = Client::new();
 
     let resp = http
-        .post(&token_url)
+        .post(token_url)
         .form(&[
             ("grant_type", "refresh_token"),
             ("client_id", client_id),
@@ -40,4 +49,86 @@ pub async fn refresh_access_token(
     resp.json::<MsTokenResponse>()
         .await
         .map_err(|e| TeamsError::AuthError(format!("Failed to parse refresh response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn refresh_access_token_posts_refresh_grant_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "new-access",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "User.Read offline_access",
+                "refresh_token": "new-refresh"
+            })))
+            .mount(&server)
+            .await;
+
+        let response = refresh_access_token_at(
+            &format!("{}/token", server.uri()),
+            "client-id",
+            "old-refresh",
+            "User.Read offline_access",
+        )
+        .await
+        .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+
+        let body = std::str::from_utf8(&requests[0].body).unwrap();
+        let form: std::collections::HashMap<String, String> =
+            url::form_urlencoded::parse(body.as_bytes())
+                .into_owned()
+                .collect();
+
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        assert_eq!(form.get("client_id").map(String::as_str), Some("client-id"));
+        assert_eq!(
+            form.get("refresh_token").map(String::as_str),
+            Some("old-refresh")
+        );
+        assert_eq!(
+            form.get("scope").map(String::as_str),
+            Some("User.Read offline_access")
+        );
+
+        assert_eq!(response.access_token, "new-access");
+        assert_eq!(response.token_type, "Bearer");
+        assert_eq!(response.expires_in, 3600);
+        assert_eq!(response.scope.as_deref(), Some("User.Read offline_access"));
+        assert_eq!(response.refresh_token.as_deref(), Some("new-refresh"));
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_maps_non_success_to_auth_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("invalid_grant"))
+            .mount(&server)
+            .await;
+
+        let err = refresh_access_token_at(
+            &format!("{}/token", server.uri()),
+            "client-id",
+            "old-refresh",
+            "User.Read offline_access",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, TeamsError::AuthError(message) if message.contains("invalid_grant")));
+    }
 }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -40,7 +40,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -242,7 +242,7 @@ pub async fn run(
                 "byo"
             };
 
-            let token = auth::resolve_token(profile).ok();
+            let token = auth::resolve_token(profile).await.ok();
             let claims = token.as_ref().and_then(|t| t.unverified_claims());
             let warnings = token_warnings(claims.as_ref());
             let admin_consent_url = delegated_admin_consent_url(&client_id, &tenant_id);
@@ -273,7 +273,7 @@ pub async fn run(
 
         AuthCommand::Status => {
             let start = Instant::now();
-            match auth::resolve_token(profile) {
+            match auth::resolve_token(profile).await {
                 Ok(token) => {
                     let claims = token.unverified_claims();
                     let msg = serde_json::json!({
@@ -312,7 +312,7 @@ pub async fn run(
         AuthCommand::Switch { name } => {
             let start = Instant::now();
             // Verify the profile has a token
-            auth::resolve_token(&name)?;
+            auth::resolve_token(&name).await?;
 
             // Update config to set default profile
             let mut updated_config = config.clone();
@@ -359,7 +359,7 @@ pub async fn run(
         AuthCommand::Token {
             format: token_format,
         } => {
-            let token = auth::resolve_token(profile)?;
+            let token = auth::resolve_token(profile).await?;
             match token_format.as_str() {
                 "json" => {
                     let claims = token.unverified_claims();

--- a/src/cli/channel.rs
+++ b/src/cli/channel.rs
@@ -104,7 +104,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -95,7 +95,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -103,7 +103,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/meeting.rs
+++ b/src/cli/meeting.rs
@@ -76,7 +76,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -238,7 +238,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/notification.rs
+++ b/src/cli/notification.rs
@@ -92,7 +92,7 @@ pub async fn run(
     profile: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -64,7 +64,7 @@ pub async fn run(
     profile: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -65,7 +65,7 @@ pub async fn run(
     profile: &str,
     format: OutputFormat,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/subscribe.rs
+++ b/src/cli/subscribe.rs
@@ -52,7 +52,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/tab.rs
+++ b/src/cli/tab.rs
@@ -52,7 +52,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -81,7 +81,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/team.rs
+++ b/src/cli/team.rs
@@ -111,7 +111,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -31,7 +31,7 @@ pub async fn run(
     format: OutputFormat,
     pagination: &PaginationOpts,
 ) -> Result<()> {
-    let token = auth::resolve_token(profile)?;
+    let token = auth::resolve_token(profile).await?;
     let client = GraphClient::new(token, &config.network)?;
 
     match cmd {


### PR DESCRIPTION
## Problem

After the access token expires (~1h after login), every command fails with exit code 3 / `AUTH_TOKEN_EXPIRED` and the user has to re-run `teams auth login` — even though a valid `refresh_token` is requested (`offline_access` is in `DEFAULT_DELEGATED_SCOPES`), returned by the token endpoint, carried on `MsTokenResponse` / `TokenInfo`, and persisted in the keyring.

The gap was in `src/auth/mod.rs::resolve_token()`: on the expired branch it returned `Err(TokenExpired)` immediately, with no `grant_type=refresh_token` redemption anywhere in the codebase. This matches the long-standing known limitation noted in the v0.2.0 changelog.

## Fix

- New `src/auth/refresh.rs` with `refresh_access_token()`, which POSTs `grant_type=refresh_token` (plus `client_id`, `refresh_token`, `scope`) to `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` and parses the response into the existing `MsTokenResponse`. Error handling mirrors `device_code::authenticate()`.
- `resolve_token()` is now `async`. When the stored token is expired (or within a 60s skew window), it attempts a silent refresh:
  - Recovers `tenant_id` (`tid`) and client id (`azp`, falling back to `appid`) from the expired access token's JWT claims via `unverified_claims()` (decoding ignores expiry).
  - Reuses the stored `scope`, ensuring `offline_access` is present so subsequent refreshes keep working; otherwise falls back to `DEFAULT_DELEGATED_SCOPES`.
  - On success, converts via `into_token_info`, persists to the keyring (best-effort), and returns the new token.
  - On any failure (no refresh token, undecodable claims, network/identity-platform rejection) it returns `Err(TokenExpired)`, so the observable behaviour and exit code are unchanged when refresh genuinely isn't possible.
- The `TEAMS_CLI_ACCESS_TOKEN` env-var path is unchanged (never refreshed).
- All `resolve_token` call sites updated to `.await` (the command handlers and `auth.rs`).
- Added unit tests for the skew/expiry logic, the scope-merging helper, and the no-refresh-token / undecodable-claims fallbacks (all network-free).
- Updated CHANGELOG, FAQ, and troubleshooting docs.

## Testing

- `cargo build` — clean
- `cargo test --all-targets` — all pass (unit + CLI integration tests), including the new auth tests
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean

Note: the live end-to-end refresh round-trip against the Microsoft identity platform was not exercised, since it requires a genuinely ~1h-expired token. The refresh request shape mirrors the existing, working device-code/PKCE token calls, and all failure paths are covered by the unit tests.

Fixes #16
