### PR TITLE
Release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.2.5 - 2026-06-21
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump teams-cli to v0.2.5
- Promote the token refresh changelog entry from Unreleased to v0.2.5
- Align Cargo.lock package metadata

## Verification
- cargo fmt -- --check
- git diff --check
- mandoc -Tlint docs/man/teams.1 docs/man/teams-config.5 docs/man/teams-auth.7 docs/man/teams-agent-contract.7 docs/man/teams-examples.7
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- cargo build --release
- cargo audit (exit 0; existing allowed transitive rand warning via reqwest)
- target/release/teams --version => teams 0.2.5