### PR TITLE
Add Scoop release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,22 @@ jobs:
               "tag": "${{ github.ref_name }}",
               "repo": "${{ github.repository }}"
             }
+
+  scoop:
+    name: Update Scoop Bucket
+    needs: release
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Update Scoop manifest
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: osodevops/scoop-bucket
+          event-type: update-teams-manifest
+          client-payload: |
+            {
+              "formula": "teams",
+              "tag": "${{ github.ref_name }}",
+              "repo": "${{ github.repository }}"
+            }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ On failure:
 # Homebrew (macOS/Linux)
 brew install osodevops/tap/teams-cli
 
+# Scoop (Windows)
+scoop bucket add osodevops https://github.com/osodevops/scoop-bucket
+scoop install teams
+
 # Pre-built binaries — download from GitHub Releases
 # https://github.com/osodevops/ms-teams-cli/releases
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -66,7 +66,7 @@ The full release path is version-bump driven, not PR-merge driven:
 4. After the PR is merged to `main`, confirm `.github/workflows/auto-tag.yml` runs successfully.
 5. Confirm `auto-tag.yml` creates the `vX.Y.Z` tag.
 6. Confirm the tag starts `.github/workflows/release.yml`.
-7. Confirm the release workflow completes all build targets, creates checksums, publishes the GitHub Release, and runs the Homebrew tap update job.
+7. Confirm the release workflow completes all build targets, creates checksums, publishes the GitHub Release, and runs the Homebrew tap and Scoop bucket update jobs.
 
 Important details:
 
@@ -80,13 +80,15 @@ Important details:
   - `aarch64-unknown-linux-musl`
   - `x86_64-pc-windows-msvc`
 
-Homebrew tap follow-up as of 2026-06-04:
+Distribution follow-up as of 2026-06-21:
 
 - `release.yml` sends a `repository_dispatch` event to `osodevops/homebrew-tap`.
+- `release.yml` sends a `repository_dispatch` event to `osodevops/scoop-bucket`.
 - The tap repository currently has no workflow listening for that dispatch event.
 - Until that automation exists, update `osodevops/homebrew-tap` manually after each CLI release.
 - Use the published `checksums-sha256.txt` from the GitHub Release to update `Formula/teams-cli.rb`.
 - Verify the remote formula points at the new release URLs and checksums.
+- The Scoop bucket has an `update-teams-manifest` workflow listener. Verify `bucket/teams.json` points at the new Windows release URL and checksum after each release.
 
 Known CI maintenance item as of 2026-06-04:
 
@@ -152,6 +154,7 @@ Already covered here:
 - GitHub Actions CI on Linux, macOS, and Windows.
 - GitHub release assets with SHA256 checksums.
 - Homebrew formula in `osodevops/homebrew-tap`.
+- Scoop manifest in `osodevops/scoop-bucket`.
 - README, docs, man pages, changelog, license, contribution guide, and security policy.
 - Agent-focused repo guidance in `AGENTS.md`.
 
@@ -164,7 +167,6 @@ Added from that comparison:
 Still intentionally not added:
 
 - cargo-dist shell and PowerShell installers.
-- Scoop bucket publishing for Windows.
 - Docker image publishing.
 - Demo repository with runnable customer scenarios.
 


### PR DESCRIPTION
## Summary
- Add a release workflow job that dispatches updates to osodevops/scoop-bucket
- Document Scoop as part of the release process
- Add Scoop install commands to README

## Verification
- ruby YAML parse of .github/workflows/release.yml
- actionlint .github/workflows/release.yml
- git diff --check