### PR TITLE
Align Scoop release dispatch with bucket token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,21 +150,16 @@ jobs:
               "repo": "${{ github.repository }}"
             }
 
-  scoop:
-    name: Update Scoop Bucket
+  publish-scoop-manifest:
+    name: Publish Scoop Manifest
     needs: release
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Update Scoop manifest
+      - name: Trigger Scoop bucket update
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
           repository: osodevops/scoop-bucket
           event-type: update-teams-manifest
-          client-payload: |
-            {
-              "formula": "teams",
-              "tag": "${{ github.ref_name }}",
-              "repo": "${{ github.repository }}"
-            }
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "tag": "${{ github.ref_name }}"}'

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -88,6 +88,7 @@ Distribution follow-up as of 2026-06-21:
 - Until that automation exists, update `osodevops/homebrew-tap` manually after each CLI release.
 - Use the published `checksums-sha256.txt` from the GitHub Release to update `Formula/teams-cli.rb`.
 - Verify the remote formula points at the new release URLs and checksums.
+- The Scoop release job uses `SCOOP_BUCKET_TOKEN`, matching the dedicated bucket-token pattern used by `osodevops/kafka-backup`.
 - The Scoop bucket has an `update-teams-manifest` workflow listener. Verify `bucket/teams.json` points at the new Windows release URL and checksum after each release.
 
 Known CI maintenance item as of 2026-06-04:


### PR DESCRIPTION
## Summary
- switch the Teams release workflow Scoop dispatch to the dedicated SCOOP_BUCKET_TOKEN used by the Scoop bucket flow
- rename the job to match the publish-scoop-manifest pattern used by kafka-backup
- document the required Scoop bucket token in release readiness notes

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- actionlint .github/workflows/release.yml
- git diff --check