### PR TITLE
Fix channel list pagination query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/api/channels.rs
+++ b/src/api/channels.rs
@@ -10,9 +10,15 @@ pub async fn list_channels(
     team_id: &str,
     pagination: &PaginationOpts,
 ) -> Result<Vec<Channel>> {
-    client
-        .get_paged(&endpoints::channels(team_id), &[], pagination)
-        .await
+    list_channels_at(client, &endpoints::channels(team_id), pagination).await
+}
+
+async fn list_channels_at(
+    client: &GraphClient,
+    url: &str,
+    pagination: &PaginationOpts,
+) -> Result<Vec<Channel>> {
+    client.get_paged_without_top(url, &[], pagination).await
 }
 
 pub async fn get_channel(client: &GraphClient, team_id: &str, channel_id: &str) -> Result<Channel> {
@@ -81,4 +87,67 @@ pub async fn remove_member(
     client
         .delete(&endpoints::channel_member(team_id, channel_id, member_id))
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::token::TokenInfo;
+    use crate::config::NetworkConfig;
+    use reqwest::Client;
+    use wiremock::matchers::{method, path, query_param_is_missing};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client() -> GraphClient {
+        GraphClient {
+            http: Client::new(),
+            token: TokenInfo {
+                access_token: "test-token".into(),
+                expires_at: None,
+                token_type: "Bearer".into(),
+                scope: None,
+                refresh_token: None,
+                profile: "default".into(),
+            },
+            network: NetworkConfig {
+                timeout: 30,
+                max_retries: 0,
+                retry_backoff_base: 2,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn list_channels_omits_top_query_parameter() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/team-id/channels"))
+            .and(query_param_is_missing("$top"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "channel-id",
+                        "displayName": "General",
+                        "membershipType": "standard"
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channels = list_channels_at(
+            &test_client(),
+            &format!("{}/teams/team-id/channels", server.uri()),
+            &PaginationOpts {
+                page_size: 50,
+                all_pages: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].display_name.as_deref(), Some("General"));
+    }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -107,6 +107,21 @@ impl GraphClient {
         }
     }
 
+    /// GET with pagination support for endpoints that reject `$top`.
+    pub async fn get_paged_without_top<T: DeserializeOwned>(
+        &self,
+        url: &str,
+        query: &[(&str, &str)],
+        pagination: &PaginationOpts,
+    ) -> Result<Vec<T>> {
+        if pagination.all_pages {
+            self.get_all_pages(url, query).await
+        } else {
+            let resp: PageResponse<T> = self.get(url, query).await?;
+            Ok(resp.value)
+        }
+    }
+
     /// POST request with JSON body.
     pub async fn post<T: DeserializeOwned, B: serde::Serialize>(
         &self,
@@ -573,5 +588,139 @@ impl GraphClient {
             status: 0,
             message: "Max retries exceeded".to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::token::TokenInfo;
+    use crate::config::NetworkConfig;
+    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client() -> GraphClient {
+        GraphClient {
+            http: Client::new(),
+            token: TokenInfo {
+                access_token: "test-token".into(),
+                expires_at: None,
+                token_type: "Bearer".into(),
+                scope: None,
+                refresh_token: None,
+                profile: "default".into(),
+            },
+            network: NetworkConfig {
+                timeout: 30,
+                max_retries: 0,
+                retry_backoff_base: 2,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn get_paged_reproduces_graph_channel_top_rejection() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/team-id/channels"))
+            .and(query_param("$top", "50"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(
+                r#"{"error":{"code":"BadRequest","message":"Unsupported query parameter 'top'."}}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let err = test_client()
+            .get_paged::<serde_json::Value>(
+                &format!("{}/teams/team-id/channels", server.uri()),
+                &[],
+                &PaginationOpts {
+                    page_size: 50,
+                    all_pages: false,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, TeamsError::ApiError { status: 400, message } if message.contains("Unsupported query parameter 'top'"))
+        );
+    }
+
+    #[tokio::test]
+    async fn get_paged_without_top_omits_top_from_first_page_request() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/team-id/channels"))
+            .and(query_param_is_missing("$top"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "channel-id",
+                        "displayName": "General",
+                        "membershipType": "standard"
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channels = test_client()
+            .get_paged_without_top::<serde_json::Value>(
+                &format!("{}/teams/team-id/channels", server.uri()),
+                &[],
+                &PaginationOpts {
+                    page_size: 50,
+                    all_pages: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0]["displayName"], "General");
+    }
+
+    #[tokio::test]
+    async fn get_paged_without_top_follows_next_link_when_all_pages_enabled() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/teams/team-id/channels"))
+            .and(query_param_is_missing("$top"))
+            .and(query_param_is_missing("page"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [{ "id": "channel-1" }],
+                "@odata.nextLink": format!("{}/teams/team-id/channels?page=2", server.uri())
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/teams/team-id/channels"))
+            .and(query_param("page", "2"))
+            .and(query_param_is_missing("$top"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [{ "id": "channel-2" }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let channels = test_client()
+            .get_paged_without_top::<serde_json::Value>(
+                &format!("{}/teams/team-id/channels", server.uri()),
+                &[],
+                &PaginationOpts {
+                    page_size: 50,
+                    all_pages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(channels.len(), 2);
+        assert_eq!(channels[0]["id"], "channel-1");
+        assert_eq!(channels[1]["id"], "channel-2");
     }
 }


### PR DESCRIPTION
## Summary
- Fix `channel list` so it does not send `$top` to the Microsoft Graph list-channels endpoint.
- Add a no-`$top` paginated GET helper that still supports `@odata.nextLink` for `--all-pages`.
- Add mocked regression tests that reproduce the Graph-style `$top` rejection and verify the fixed channel-list path.
- Update transitive `quinn-proto` lockfile pin from `0.11.14` to `0.11.15` to resolve `RUSTSEC-2026-0185` found during release checks.

Closes #23

## Verification
- `cargo fmt -- --check`
- `cargo test --all-targets`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo audit` exits cleanly with only the existing allowed `rand` warning
