### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.6 - 2026-06-26
+
+### Fixed
+
+- Fixed `teams channel list` pagination so it no longer sends the unsupported `$top` query parameter to Microsoft Graph's list-channels endpoint. The command still follows `@odata.nextLink` when `--all-pages` is used. This resolves #23.
+- Updated the transitive `quinn-proto` lockfile pin to `0.11.15` to resolve `RUSTSEC-2026-0185`.
+
 ## v0.2.5 - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `teams-cli` from `0.2.5` to `0.2.6` in `Cargo.toml`.
- Align the root package version in `Cargo.lock`.
- Add the `v0.2.6` changelog entry for the channel-list pagination fix from #23 and the `quinn-proto` audit fix.

## Release trigger
This repository's release workflow is version-bump driven. After this PR merges to `main`, `.github/workflows/auto-tag.yml` should detect the `Cargo.toml` package version change, create `v0.2.6`, and that tag should trigger `.github/workflows/release.yml`.

## Verification
- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo audit` exits cleanly with only the existing allowed `rand` warning
