### PR TITLE
fix: omit unsupported `$top` query option on chat members list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.7 - 2026-06-29
+
+### Fixed
+
+- Fixed `teams chat members list` so it no longer sends the unsupported `$top` query parameter to Microsoft Graph's list-chat-members endpoint. The command still follows `@odata.nextLink` when `--all-pages` is used. This resolves #27.
+
 ## v0.2.6 - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/src/api/chats.rs
+++ b/src/api/chats.rs
@@ -28,9 +28,17 @@ pub async fn list_members(
     chat_id: &str,
     pagination: &PaginationOpts,
 ) -> Result<Vec<ConversationMember>> {
-    client
-        .get_paged(&endpoints::chat_members(chat_id), &[], pagination)
-        .await
+    list_members_at(client, &endpoints::chat_members(chat_id), pagination).await
+}
+
+/// `GET /chats/{id}/members` doesn't support the `$top` OData query option
+/// (Graph returns HTTP 400), so page via `@odata.nextLink` only.
+async fn list_members_at(
+    client: &GraphClient,
+    url: &str,
+    pagination: &PaginationOpts,
+) -> Result<Vec<ConversationMember>> {
+    client.get_paged_without_top(url, &[], pagination).await
 }
 
 pub async fn add_member(
@@ -67,4 +75,67 @@ pub async fn unhide_chat(client: &GraphClient, chat_id: &str, user_id: &str) -> 
     client
         .post_no_content(&endpoints::chat_unhide(chat_id), &body)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::token::TokenInfo;
+    use crate::config::NetworkConfig;
+    use reqwest::Client;
+    use wiremock::matchers::{method, path, query_param_is_missing};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client() -> GraphClient {
+        GraphClient {
+            http: Client::new(),
+            token: TokenInfo {
+                access_token: "test-token".into(),
+                expires_at: None,
+                token_type: "Bearer".into(),
+                scope: None,
+                refresh_token: None,
+                profile: "default".into(),
+            },
+            network: NetworkConfig {
+                timeout: 30,
+                max_retries: 0,
+                retry_backoff_base: 2,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn list_members_omits_top_query_parameter() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/chats/chat-id/members"))
+            .and(query_param_is_missing("$top"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "member-id",
+                        "displayName": "Alice",
+                        "roles": ["owner"]
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let members = list_members_at(
+            &test_client(),
+            &format!("{}/chats/chat-id/members", server.uri()),
+            &PaginationOpts {
+                page_size: 50,
+                all_pages: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].display_name.as_deref(), Some("Alice"));
+    }
 }


### PR DESCRIPTION
Fixes #27.

`teams chat members list <chat-id>` failed with HTTP 400 because `chats::list_members` appended `$top` to `GET /chats/{id}/members`, which [doesn't support OData query parameters](https://learn.microsoft.com/en-us/graph/api/chat-list-members). Microsoft Graph rejects the request with `Query option 'Top' is not allowed`.

This routes `list_members` through the existing `GraphClient::get_paged_without_top` — added in #24 for the same class of bug on `list_channels` — so the request pages via `@odata.nextLink` without `$top`.

## Changes

- `chats::list_members` now delegates to a private `list_members_at(url, ...)` helper that calls `get_paged_without_top`, mirroring the `list_channels` / `list_channels_at` shape introduced in #24.
- Adds a `wiremock` unit test `list_members_omits_top_query_parameter` asserting the outgoing request carries no `$top` (matches the `list_channels_omits_top_query_parameter` test).

## Verification

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets` — all green (76 unit + 44 integration).
- Live against a real group chat: `teams chat members list <chat-id>` now returns members instead of a 400.

Scope is intentionally limited to chat members. Team members and channel members both document `$top` support, so they're unchanged.
