### PR TITLE
fix: create chats via POST /chats with per-member roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## v0.2.7 - 2026-06-29
 
+### Added
+
+- `teams chat create --members` now accepts an optional per-member role suffix (`<user-id>:guest`) so chats can include Azure AD guest users. Members without a suffix default to `owner`, which is what Microsoft Graph expects for regular tenant users in personal chats. This resolves part of #30.
+
 ### Fixed
+
+- Fixed `teams chat create`, which always failed against Microsoft Graph: it POSTed to the list-only `/me/chats` endpoint (HTTP 405) and sent members without the required role (HTTP 400). Chat creation now POSTs to `/chats` with an explicit role per member. This resolves #30.
 
 - Fixed `teams chat members list` so it no longer sends the unsupported `$top` query parameter to Microsoft Graph's list-chat-members endpoint. The command still follows `@odata.nextLink` when `--all-pages` is used. This resolves #27.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.7 - 2026-06-29
+## Unreleased
 
 ### Added
 
@@ -9,6 +9,10 @@
 ### Fixed
 
 - Fixed `teams chat create`, which always failed against Microsoft Graph: it POSTed to the list-only `/me/chats` endpoint (HTTP 405) and sent members without the required role (HTTP 400). Chat creation now POSTs to `/chats` with an explicit role per member. This resolves #30.
+
+## v0.2.7 - 2026-06-29
+
+### Fixed
 
 - Fixed `teams chat members list` so it no longer sends the unsupported `$top` query parameter to Microsoft Graph's list-chat-members endpoint. The command still follows `@odata.nextLink` when `--all-pages` is used. This resolves #27.
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ teams message unpin --team <team-id> --channel <channel-id> --pinned-message-id 
 teams chat list
 teams chat get <chat-id>
 teams chat create --type oneOnOne --members <user-id-1>,<user-id-2>
+teams chat create --type oneOnOne --members <your-user-id>,<guest-user-id>:guest   # chat with a guest user
 teams chat hide <chat-id>
 teams chat unhide <chat-id>
 teams chat members list <chat-id>

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -112,7 +112,7 @@ Normal message mutation requires delegated auth. App-only/client-credentials tok
 ```bash
 teams chat list
 teams chat get CHAT_ID
-teams chat create [--chat-type group|oneOnOne] [--type group|oneOnOne] [--topic TOPIC] [--members USER_ID,USER_ID]
+teams chat create [--chat-type group|oneOnOne] [--type group|oneOnOne] [--topic TOPIC] [--members USER_ID[:owner|guest],USER_ID[:owner|guest]]
 teams chat update CHAT_ID --topic TOPIC
 teams chat hide CHAT_ID --user-id USER_ID
 teams chat unhide CHAT_ID --user-id USER_ID
@@ -120,6 +120,8 @@ teams chat members list CHAT_ID
 teams chat members add CHAT_ID --user-id USER_ID [--role member|owner]
 teams chat members remove CHAT_ID MEMBER_ID
 ```
+
+When creating a chat, members default to the `owner` role. Azure AD guest users must be marked with a `:guest` suffix (e.g. `--members <your-id>,<guest-id>:guest`) or Microsoft Graph rejects the request.
 
 Some meeting chats can appear in `chat list` but reject message reads if the signed-in user is no longer in the meeting roster. Treat that as a per-chat skip, not as proof that auth is broken.
 

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -147,7 +147,7 @@ and
 .nf
 teams chat list
 teams chat get CHAT_ID
-teams chat create [--chat-type group|oneOnOne] [--type group|oneOnOne] [--topic TOPIC] [--members USER_ID,USER_ID]
+teams chat create [--chat-type group|oneOnOne] [--type group|oneOnOne] [--topic TOPIC] [--members USER_ID[:owner|guest],USER_ID[:owner|guest]]
 teams chat update CHAT_ID --topic TOPIC
 teams chat hide CHAT_ID --user-id USER_ID
 teams chat unhide CHAT_ID --user-id USER_ID

--- a/src/api/chats.rs
+++ b/src/api/chats.rs
@@ -16,7 +16,13 @@ pub async fn get_chat(client: &GraphClient, id: &str) -> Result<Chat> {
 }
 
 pub async fn create_chat(client: &GraphClient, req: &ChatCreateRequest) -> Result<Chat> {
-    client.post(&endpoints::my_chats(), req).await
+    create_chat_at(client, &endpoints::chats(), req).await
+}
+
+/// Chat creation must POST to `/chats`; the `/me/chats` endpoint is list-only
+/// and answers POST with HTTP 405.
+async fn create_chat_at(client: &GraphClient, url: &str, req: &ChatCreateRequest) -> Result<Chat> {
+    client.post(url, req).await
 }
 
 pub async fn update_chat(client: &GraphClient, id: &str, req: &ChatUpdateRequest) -> Result<Chat> {
@@ -83,7 +89,7 @@ mod tests {
     use crate::auth::token::TokenInfo;
     use crate::config::NetworkConfig;
     use reqwest::Client;
-    use wiremock::matchers::{method, path, query_param_is_missing};
+    use wiremock::matchers::{body_partial_json, method, path, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client() -> GraphClient {
@@ -137,5 +143,47 @@ mod tests {
 
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].display_name.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn chat_creation_endpoint_is_not_scoped_to_me() {
+        assert_eq!(endpoints::chats(), "https://graph.microsoft.com/v1.0/chats");
+    }
+
+    #[tokio::test]
+    async fn create_chat_posts_member_roles() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chats"))
+            .and(body_partial_json(serde_json::json!({
+                "chatType": "group",
+                "members": [
+                    { "roles": ["owner"] },
+                    { "roles": ["guest"] }
+                ]
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "chat-id",
+                "chatType": "group",
+                "topic": "Vendor sync"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let req = ChatCreateRequest {
+            chat_type: "group".to_string(),
+            topic: Some("Vendor sync".to_string()),
+            members: vec![
+                AddMemberRequest::new("tenant-user", vec!["owner".to_string()]),
+                AddMemberRequest::new("guest-user", vec!["guest".to_string()]),
+            ],
+        };
+        let chat = create_chat_at(&test_client(), &format!("{}/chats", server.uri()), &req)
+            .await
+            .unwrap();
+
+        assert_eq!(chat.id.as_deref(), Some("chat-id"));
+        assert_eq!(chat.topic.as_deref(), Some("Vendor sync"));
     }
 }

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -111,6 +111,12 @@ pub fn my_chats() -> String {
     format!("{GRAPH_V1}/me/chats")
 }
 
+/// Chat creation lives at `/chats`; `/me/chats` is list-only and returns
+/// HTTP 405 for POST.
+pub fn chats() -> String {
+    format!("{GRAPH_V1}/chats")
+}
+
 pub fn chat(id: &str) -> String {
     format!("{GRAPH_V1}/chats/{id}")
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crate::api::{self, GraphClient, PaginationOpts};
 use crate::auth;
 use crate::config::ConfigFile;
-use crate::error::Result;
+use crate::error::{Result, TeamsError};
 use crate::models::chat::{ChatCreateRequest, ChatUpdateRequest};
 use crate::models::member::AddMemberRequest;
 use crate::output::{self, OutputFormat};
@@ -26,7 +26,8 @@ pub enum ChatCommand {
         /// Topic for the chat (group chats only)
         #[arg(long)]
         topic: Option<String>,
-        /// User IDs to add as members (comma-separated)
+        /// Members as comma-separated user IDs; append `:guest` for guest
+        /// users (e.g. `<id>,<id>:guest`). Default role is owner.
         #[arg(long, value_delimiter = ',')]
         members: Vec<String>,
     },
@@ -137,8 +138,11 @@ pub async fn run(
             let start = Instant::now();
             let member_reqs: Vec<AddMemberRequest> = members
                 .iter()
-                .map(|uid| AddMemberRequest::new(uid, vec![]))
-                .collect();
+                .map(|spec| {
+                    let (user_id, role) = parse_member_spec(spec)?;
+                    Ok(AddMemberRequest::new(&user_id, vec![role]))
+                })
+                .collect::<Result<_>>()?;
             let req = ChatCreateRequest {
                 chat_type,
                 topic,
@@ -174,6 +178,30 @@ pub async fn run(
         }
 
         ChatCommand::Members { command } => run_members(command, &client, format, pagination).await,
+    }
+}
+
+/// Splits a `--members` entry of the form `<user-id>[:role]`.
+///
+/// Graph requires every member in a chat-creation request to carry an explicit
+/// role: `owner` for regular tenant users (all participants of a personal chat
+/// are owners) and `guest` for Azure AD guest users. Entries without a suffix
+/// default to `owner`.
+fn parse_member_spec(spec: &str) -> Result<(String, String)> {
+    let (user_id, role) = match spec.split_once(':') {
+        Some((user_id, role)) => (user_id, role),
+        None => (spec, "owner"),
+    };
+    if user_id.is_empty() {
+        return Err(TeamsError::InvalidInput(format!(
+            "empty user ID in --members entry '{spec}'"
+        )));
+    }
+    match role {
+        "owner" | "guest" => Ok((user_id.to_string(), role.to_string())),
+        other => Err(TeamsError::InvalidInput(format!(
+            "invalid role '{other}' in --members entry '{spec}' (expected 'owner' or 'guest')"
+        ))),
     }
 }
 
@@ -227,5 +255,36 @@ async fn run_members(
             output::print_success(format, &result, start);
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_spec_defaults_to_owner() {
+        let (user_id, role) = parse_member_spec("user-1").unwrap();
+        assert_eq!(user_id, "user-1");
+        assert_eq!(role, "owner");
+    }
+
+    #[test]
+    fn member_spec_accepts_guest_suffix() {
+        let (user_id, role) = parse_member_spec("user-2:guest").unwrap();
+        assert_eq!(user_id, "user-2");
+        assert_eq!(role, "guest");
+    }
+
+    #[test]
+    fn member_spec_rejects_unknown_role() {
+        let err = parse_member_spec("user-3:admin").unwrap_err();
+        assert!(matches!(err, TeamsError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn member_spec_rejects_empty_user_id() {
+        let err = parse_member_spec(":guest").unwrap_err();
+        assert!(matches!(err, TeamsError::InvalidInput(_)));
     }
 }


### PR DESCRIPTION
Fixes the two stacked Graph errors from #30 that made `teams chat create` always fail: the request now POSTs to `/chats` instead of the list-only `/me/chats` (which answers 405), and every member goes out with an explicit role instead of empty `roles` (which drew a 400).

While in there, `--members` gained an optional per-entry role suffix so new chats can include Azure AD guest users:

```
teams chat create --type oneOnOne --members <your-id>,<guest-id>:guest
```

Entries without a suffix default to `owner`, matching what Graph expects for regular tenant users in personal chats, so existing invocations behave the same. Unknown roles or empty IDs fail fast with an invalid-input error.

Tests follow the existing wiremock pattern in `src/api/chats.rs`: one asserts creation POSTs to `/chats` with per-member roles in the body, one pins `endpoints::chats()` so the `/me/chats` regression can't sneak back, and four cover the `--members` suffix parsing. Docs (README, command reference, man page) and the changelog are updated.

The owner path works against our tenant; the guest path follows the documented Graph shape but has only been exercised in tests so far.

Resolves #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXLtdKh5Ntf2DxmQ7d2wbN
