### PR TITLE
feat(auth): per-profile delegated scopes and silent auth refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,15 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 ```
+
+The optional `scopes` field replaces the default delegated scope string for
+that profile, so a BYO app with admin-consented permissions (for example
+`People.Read` for people search) can request them on every login without
+passing `--scopes`. The value is used verbatim except that `offline_access` is
+appended when missing. The default scope set is unchanged for profiles that
+omit the field.
 
 Then sign in:
 
@@ -221,6 +229,10 @@ admin-consent required. Use `--scopes` or a customer-owned app when a workflow
 needs channel message reads.
 
 **Credential resolution order**: CLI flags > environment variables > config file profiles.
+
+Delegated scope resolution follows the same order: `--scopes` (or
+`TEAMS_CLI_SCOPES`), then the profile's `scopes` field, then the built-in
+default scope set.
 
 ### Why not import Teams client tokens?
 
@@ -546,6 +558,7 @@ auth_flow = "device-code"
 | `TEAMS_CLI_CLIENT_ID` | Azure AD application (client) ID |
 | `TEAMS_CLI_CLIENT_SECRET` | Azure AD client secret |
 | `TEAMS_CLI_TENANT_ID` | Azure AD tenant ID |
+| `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login (same precedence as `--scopes`; ignored by client credentials) |
 | `TEAMS_CLI_ACCESS_TOKEN` | Pre-obtained Microsoft Graph access token (skips login entirely) |
 | `RUST_LOG` | Tracing filter (e.g., `debug`, `teams=trace`) |
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ Delegated scope resolution follows the same order: `--scopes` (or
 `TEAMS_CLI_SCOPES`), then the profile's `scopes` field, then the built-in
 default scope set.
 
+When permissions are consented after login (for example an admin grants a new
+delegated scope), `teams auth refresh` silently redeems the stored refresh
+token for the resolved scopes — no browser or device code. Refresh tokens are
+bound to the user and client, not to the originally requested scopes, so the
+upgrade succeeds for any scope set already consented for the app. Without an
+explicit override the stored token's scope is reused, so a plain refresh never
+narrows a session. If consent is missing, the identity platform rejects the
+request and the CLI prints the matching `consent-url` command to fix it.
+
 ### Why not import Teams client tokens?
 
 Tools such as `fossteams/teams-token` are attractive because they avoid Entra
@@ -312,6 +321,7 @@ esac
 teams auth login             # Interactive login (browser)
 teams auth login --device-code  # Device code flow
 teams auth login --client-credentials  # App-only Graph operations where supported
+teams auth refresh           # Silently redeem the refresh token (picks up newly consented scopes)
 teams auth status            # Check if session is valid (exit code 0/1)
 teams auth consent-url       # Print admin consent URL for the active auth app
 teams auth doctor            # Diagnose config and token state

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -138,6 +138,25 @@ explicit opt-in for BYO app registrations. Do not use
 every permission configured on the app registration instead of the explicit
 scope list.
 
+## Upgrading scopes without re-login
+
+Refresh tokens are bound to the user and client, not to the scopes originally
+requested, so an existing session can be upgraded to newly consented
+permissions silently — the same mechanism MSAL uses for incremental consent:
+
+```bash
+teams auth consent-url --scopes "User.Read People.Read offline_access"  # admin grants once
+teams auth refresh                                                      # silent upgrade, no browser
+```
+
+`auth refresh` redeems the stored refresh token for the resolved scope string
+(`--scopes`/`TEAMS_CLI_SCOPES`, then profile `scopes`). Without an explicit
+override it reuses the stored token's scope, so a plain refresh never narrows
+an existing session. If a requested scope has not been consented, the
+identity platform rejects the whole request (AADSTS65001) rather than issuing
+a narrower token; the CLI then prints the exact `consent-url` command to
+grant it, or fall back to `teams auth login` for interactive consent.
+
 Customer-owned delegated app:
 
 ```bash

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -115,6 +115,29 @@ Custom scopes:
 teams auth login --device-code --scopes "User.Read ChatMessage.Send offline_access"
 ```
 
+Scopes can also be pinned per profile so every login for that profile requests
+them without repeating `--scopes`:
+
+```toml
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
+```
+
+The profile `scopes` value replaces the default delegated scope string (it is
+not additive); `offline_access` is appended when missing so refresh tokens
+keep working. Resolution order is `--scopes` or `TEAMS_CLI_SCOPES`, then the
+profile `scopes` field, then the default scope set. `teams auth consent-url`
+and `teams auth doctor` reflect the profile's resolved scopes, so admin
+consent links match what login will request. The default scope set remains
+free of admin-consent-required permissions; requesting broader scopes is an
+explicit opt-in for BYO app registrations. Do not use
+`https://graph.microsoft.com/.default` for delegated login — it would pull in
+every permission configured on the app registration instead of the explicit
+scope list.
+
 Customer-owned delegated app:
 
 ```bash
@@ -231,6 +254,7 @@ teams auth logout --all
 | `TEAMS_CLI_CLIENT_ID` | Entra app client ID. |
 | `TEAMS_CLI_CLIENT_SECRET` | Client secret for client credentials flow. |
 | `TEAMS_CLI_TENANT_ID` | Tenant ID or tenant domain. |
+| `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login. Same precedence as `--scopes`; ignored by client credentials login. |
 | `TEAMS_CLI_DISABLE_KEYRING` | Test-only escape hatch used by CLI tests to avoid real OS keyring access. |
 
 ## Microsoft references

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -26,8 +26,9 @@ teams [OPTIONS] <COMMAND>
 ```bash
 teams auth login [--device-code] [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth login --client-credentials --client-id ID --client-secret SECRET --tenant-id ID
+teams auth refresh [--scopes SCOPES]
 teams auth status
-teams auth consent-url [--client-id ID] [--tenant-id ID]
+teams auth consent-url [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth doctor [--client-id ID] [--tenant-id ID]
 teams auth list
 teams auth switch NAME
@@ -38,6 +39,8 @@ teams auth token [--format bearer|json]
 Delegated login defaults to the OSO public client app. Client credentials always require explicit customer credentials.
 
 Delegated scopes resolve as `--scopes` (or `TEAMS_CLI_SCOPES`), then the profile's `scopes` config field, then the built-in default scope set. `offline_access` is always ensured. `consent-url` and `doctor` reflect the resolved profile scopes.
+
+`auth refresh` silently redeems the stored refresh token for the resolved scopes — no browser — picking up newly admin-consented permissions. Without an explicit scope override it reuses the stored token's scope, never narrowing the session.
 
 ## Users
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -37,6 +37,8 @@ teams auth token [--format bearer|json]
 
 Delegated login defaults to the OSO public client app. Client credentials always require explicit customer credentials.
 
+Delegated scopes resolve as `--scopes` (or `TEAMS_CLI_SCOPES`), then the profile's `scopes` config field, then the built-in default scope set. `offline_access` is always ensured. `consent-url` and `doctor` reflect the resolved profile scopes.
+
 ## Users
 
 ```bash

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -52,7 +52,15 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 .fi
+.PP
+The optional
+.B scopes
+field replaces the default delegated scope string for that profile;
+.B offline_access
+is appended when missing. Use it when a BYO app has admin-consented
+permissions beyond the defaults.
 .PP
 Then run:
 .PP
@@ -117,6 +125,11 @@ Client secret for client credentials flow.
 .TP
 .B TEAMS_CLI_TENANT_ID
 Tenant ID or tenant domain.
+.TP
+.B TEAMS_CLI_SCOPES
+Delegated OAuth scopes for login. Same precedence as
+.B --scopes.
+Ignored by client credentials login.
 .TP
 .B TEAMS_CLI_DISABLE_KEYRING
 Test-only switch used to avoid OS keyring access in automated tests. Do not use

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -102,6 +102,27 @@ For unattended service-identity posting, the intended future direction is a
 Teams app/bot proactive messaging mode. In that model a customer installs a
 Teams app or bot, and messages are sent as that app identity instead of a
 delegated human user.
+.SH SCOPE UPGRADES
+Refresh tokens are bound to the user and client, not to the scopes originally
+requested, so an existing session can pick up newly consented delegated
+permissions without interactive re-auth:
+.PP
+.nf
+teams auth consent-url --scopes "User.Read People.Read offline_access"
+teams auth refresh
+.fi
+.PP
+.B auth refresh
+redeems the stored refresh token for the resolved scopes (\fB--scopes\fR or
+.B TEAMS_CLI_SCOPES,
+then the profile
+.B scopes
+field). Without an explicit override it reuses the stored token's scope, so a
+plain refresh never narrows a session. If a requested scope has not been
+consented, the identity platform rejects the request (AADSTS65001) instead of
+issuing a narrower token; grant consent and retry, or run
+.B teams auth login
+for interactive consent.
 .SH TOKEN STORAGE
 Tokens are stored in the operating system credential store:
 .PP
@@ -136,8 +157,10 @@ Test-only switch used to avoid OS keyring access in automated tests. Do not use
 for real login sessions.
 .SH KNOWN GAPS
 Stored access tokens are refreshed automatically when a refresh token is
-available. If the refresh token is missing, expired, revoked, or rejected by
-the identity platform, run:
+available. Use
+.B teams auth refresh
+to force a refresh explicitly. If the refresh token is missing, expired,
+revoked, or rejected by the identity platform, run:
 .PP
 .nf
 teams auth login --device-code

--- a/docs/man/teams-config.5
+++ b/docs/man/teams-config.5
@@ -46,6 +46,7 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 .fi
 .SH DEFAULT SECTION
 .TP
@@ -129,6 +130,12 @@ used by docs and examples include
 .B device-code,
 and
 .B auth-code-pkce.
+.TP
+.B scopes
+Delegated OAuth scope string requested at login for this profile. Replaces the
+built-in default delegated scopes;
+.B offline_access
+is appended when missing. Ignored by client credentials login.
 .SH RESOLUTION ORDER
 Client ID and tenant ID resolution:
 .nf
@@ -141,6 +148,13 @@ Client secret resolution:
 .nf
 1. CLI flag
 2. TEAMS_CLI_CLIENT_SECRET
+.fi
+.PP
+Delegated scope resolution:
+.nf
+1. --scopes flag or TEAMS_CLI_SCOPES
+2. Selected config profile scopes
+3. Built-in default delegated scopes
 .fi
 .PP
 Access token resolution for normal commands:

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -72,6 +72,13 @@ Credential resolution for explicit client ID and tenant ID is CLI flag,
 environment variable, then config profile. Client secret resolution is CLI
 flag, then
 .B TEAMS_CLI_CLIENT_SECRET.
+Delegated scope resolution is
+.B --scopes
+or
+.B TEAMS_CLI_SCOPES,
+then the profile
+.B scopes
+field, then the built-in default delegated scopes.
 Normal command token resolution is
 .B TEAMS_CLI_ACCESS_TOKEN
 then the OS keyring token for the selected profile.
@@ -263,6 +270,11 @@ Azure AD client secret for client credentials auth.
 .TP
 .B TEAMS_CLI_TENANT_ID
 Azure AD tenant ID.
+.TP
+.B TEAMS_CLI_SCOPES
+Delegated OAuth scopes for login. Same precedence as
+.B --scopes.
+Ignored by client credentials login.
 .TP
 .B RUST_LOG
 Tracing filter, for example

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -51,8 +51,9 @@ Follow Graph pagination and return all pages.
 .SH AUTHENTICATION
 .nf
 teams auth login [--client-credentials] [--device-code] [--client-id ID] [--client-secret SECRET] [--tenant-id ID] [--scopes SCOPES]
+teams auth refresh [--scopes SCOPES]
 teams auth status
-teams auth consent-url [--client-id ID] [--tenant-id ID]
+teams auth consent-url [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth doctor [--client-id ID] [--tenant-id ID]
 teams auth list
 teams auth switch NAME
@@ -79,6 +80,10 @@ or
 then the profile
 .B scopes
 field, then the built-in default delegated scopes.
+.B teams auth refresh
+silently redeems the stored refresh token for the resolved scopes, picking up
+newly admin-consented permissions without a browser; without an explicit
+override it reuses the stored token's scope.
 Normal command token resolution is
 .B TEAMS_CLI_ACCESS_TOKEN
 then the OS keyring token for the selected profile.

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -7,7 +7,7 @@ pub mod token;
 
 use chrono::{Duration, Utc};
 
-use crate::config::DEFAULT_DELEGATED_SCOPES;
+use crate::config::{ensure_offline_access, DEFAULT_DELEGATED_SCOPES};
 use crate::error::{Result, TeamsError};
 use token::TokenInfo;
 
@@ -128,13 +128,7 @@ fn refreshed_token_info(
 /// back to the default delegated scopes.
 fn refresh_scope(existing: Option<&str>) -> String {
     match existing {
-        Some(scope) if !scope.trim().is_empty() => {
-            if scope.split_whitespace().any(|s| s == "offline_access") {
-                scope.to_string()
-            } else {
-                format!("{scope} offline_access")
-            }
-        }
+        Some(scope) if !scope.trim().is_empty() => ensure_offline_access(scope),
         _ => DEFAULT_DELEGATED_SCOPES.to_string(),
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -79,6 +79,58 @@ fn handle_refresh_failure(info: &TokenInfo, error: TeamsError) -> Result<TokenIn
 /// cannot be refreshed — e.g. no refresh token, undecodable claims, or the
 /// identity platform rejecting the request.
 async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
+    let scope = refresh_scope(info.scope.as_deref());
+    let refreshed = redeem_refresh_token(profile, info, &scope).await?;
+
+    // Best-effort persistence so the next invocation reuses the new token.
+    let _ = keyring::store_token(profile, &refreshed);
+
+    Ok(refreshed)
+}
+
+/// Redeem the stored refresh token for a delegated scope string, no
+/// interactive login. Refresh tokens are bound to user + client, not to the
+/// originally requested scopes, so this succeeds for any scope set already
+/// consented for the app — the mechanism behind `teams auth refresh` picking
+/// up newly admin-consented permissions silently. An unconsented scope makes
+/// the identity platform reject the whole request (AADSTS65001) rather than
+/// return a narrower token.
+///
+/// Without an explicit `scope` override the stored token's scope is reused,
+/// so a plain refresh never down-scopes a token that was minted with more
+/// than the defaults. Returns the scope string that was requested alongside
+/// the refreshed token.
+pub async fn refresh_token_with_scopes(
+    profile: &str,
+    scope: Option<&str>,
+) -> Result<(TokenInfo, String)> {
+    let info = keyring::get_token(profile).map_err(|_| {
+        TeamsError::AuthError("Not authenticated. Run `teams auth login` first.".into())
+    })?;
+
+    if info.refresh_token.is_none() {
+        return Err(TeamsError::AuthError(
+            "Stored token has no refresh token to redeem. Run `teams auth login` first.".into(),
+        ));
+    }
+
+    let scope = match scope {
+        Some(explicit) => explicit.to_string(),
+        None => refresh_scope(info.scope.as_deref()),
+    };
+
+    let refreshed = redeem_refresh_token(profile, &info, &scope).await?;
+
+    // The upgraded token is the whole point of the command, so a persistence
+    // failure is a hard error here, unlike the best-effort background refresh.
+    keyring::store_token(profile, &refreshed)?;
+
+    Ok((refreshed, scope))
+}
+
+/// Redeem the stored refresh token for the given scope string. Does not
+/// persist the result; callers decide whether storage failures are fatal.
+async fn redeem_refresh_token(profile: &str, info: &TokenInfo, scope: &str) -> Result<TokenInfo> {
     let refresh_token = info
         .refresh_token
         .as_deref()
@@ -93,16 +145,10 @@ async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
         .or(claims.appid)
         .ok_or(TeamsError::TokenExpired)?;
 
-    let scope = refresh_scope(info.scope.as_deref());
-
     let response =
-        refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, &scope).await?;
-    let refreshed = refreshed_token_info(profile, info, response);
+        refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, scope).await?;
 
-    // Best-effort persistence so the next invocation reuses the new token.
-    let _ = keyring::store_token(profile, &refreshed);
-
-    Ok(refreshed)
+    Ok(refreshed_token_info(profile, info, response))
 }
 
 fn refreshed_token_info(

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -34,6 +34,12 @@ pub enum AuthCommand {
         #[arg(long, env = "TEAMS_CLI_SCOPES")]
         scopes: Option<String>,
     },
+    /// Silently redeem the stored refresh token for the resolved delegated scopes
+    Refresh {
+        /// OAuth scopes (space-separated, for delegated flows)
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
+        scopes: Option<String>,
+    },
     /// Check current auth status
     Status,
     /// Print the admin consent URL for the active auth app
@@ -45,6 +51,10 @@ pub enum AuthCommand {
         /// Azure AD tenant ID or domain
         #[arg(long, env = "TEAMS_CLI_TENANT_ID")]
         tenant_id: Option<String>,
+
+        /// OAuth scopes (space-separated) to include in the consent URL
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
+        scopes: Option<String>,
     },
     /// Diagnose auth configuration and current token state
     Doctor {
@@ -124,6 +134,36 @@ fn graph_admin_consent_scopes(scopes: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Turn the identity platform's consent-required rejection (AADSTS65001) of a
+/// refresh-token redemption into actionable guidance. The platform rejects the
+/// whole request when any requested scope lacks consent; it never returns a
+/// narrower token. When an explicit scope override failed, the guidance names
+/// it so the consent URL covers the exact scope set that was rejected.
+fn annotate_consent_error(
+    error: TeamsError,
+    profile: &str,
+    requested_scopes: Option<&str>,
+) -> TeamsError {
+    match error {
+        TeamsError::AuthError(message)
+            if message.contains("AADSTS65001") || message.contains("consent_required") =>
+        {
+            let consent_command = match requested_scopes {
+                Some(scopes) => {
+                    format!("teams --profile {profile} auth consent-url --scopes \"{scopes}\"")
+                }
+                None => format!("teams --profile {profile} auth consent-url"),
+            };
+            TeamsError::AuthError(format!(
+                "{message}\n\nThe requested scopes have not been consented for this app. \
+                 Grant admin consent (run `{consent_command}` for the URL) and retry, or run \
+                 `teams --profile {profile} auth login` for interactive consent."
+            ))
+        }
+        other => other,
+    }
 }
 
 fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
@@ -207,16 +247,40 @@ pub async fn run(
             Ok(())
         }
 
+        AuthCommand::Refresh { scopes } => {
+            let start = Instant::now();
+            // No explicit override means the stored token's scope is reused,
+            // so a plain refresh never down-scopes a previously broader login.
+            let override_scopes =
+                config::resolve_delegated_scopes_override(scopes.as_deref(), profile, config);
+
+            let (token_info, requested_scope) =
+                auth::refresh_token_with_scopes(profile, override_scopes.as_deref())
+                    .await
+                    .map_err(|e| annotate_consent_error(e, profile, override_scopes.as_deref()))?;
+
+            let msg = serde_json::json!({
+                "message": "Token refreshed successfully",
+                "profile": profile,
+                "requested_scope": requested_scope,
+                "granted_scope": token_info.scope,
+                "expires_at": token_info.expires_at.map(|e| e.to_rfc3339()),
+            });
+            output::print_success(format, &msg, start);
+            Ok(())
+        }
+
         AuthCommand::ConsentUrl {
             client_id,
             tenant_id,
+            scopes,
         } => {
             let start = Instant::now();
             let client_id =
                 config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
             let tenant_id =
                 config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-            let scopes = config::resolve_delegated_scopes(None, profile, config);
+            let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
             let url = delegated_admin_consent_url(&client_id, &tenant_id, &scopes);
             let msg = serde_json::json!({
                 "admin_consent_url": url,
@@ -384,5 +448,47 @@ pub async fn run(
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn annotate_consent_error_adds_guidance_with_requested_scopes() {
+        let error = TeamsError::AuthError("Token refresh failed: AADSTS65001: no consent".into());
+        let annotated = annotate_consent_error(error, "work", Some("User.Read People.Read"));
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(message.contains("AADSTS65001"));
+        assert!(message
+            .contains("teams --profile work auth consent-url --scopes \"User.Read People.Read\""));
+        assert!(message.contains("--profile work auth login"));
+    }
+
+    #[test]
+    fn annotate_consent_error_omits_scopes_flag_without_override() {
+        let error = TeamsError::AuthError("consent_required".into());
+        let annotated = annotate_consent_error(error, "default", None);
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(message.contains("`teams --profile default auth consent-url`"));
+        assert!(!message.contains("--scopes"));
+    }
+
+    #[test]
+    fn annotate_consent_error_passes_through_other_errors() {
+        let error = TeamsError::AuthError("Token refresh failed: AADSTS70008 expired".into());
+        let annotated = annotate_consent_error(error, "default", None);
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(!message.contains("consent-url"));
     }
 }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -31,7 +31,7 @@ pub enum AuthCommand {
         tenant_id: Option<String>,
 
         /// OAuth scopes (space-separated, for delegated flows)
-        #[arg(long)]
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
         scopes: Option<String>,
     },
     /// Check current auth status
@@ -126,8 +126,8 @@ fn graph_admin_consent_scopes(scopes: &str) -> String {
         .join(" ")
 }
 
-fn delegated_admin_consent_url(client_id: &str, tenant_id: &str) -> String {
-    let scopes = graph_admin_consent_scopes(config::DEFAULT_DELEGATED_SCOPES);
+fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
+    let scopes = graph_admin_consent_scopes(delegated_scopes);
     format!(
         "https://login.microsoftonline.com/{tenant_id}/v2.0/adminconsent?client_id={client_id}&scope={}&redirect_uri={}",
         urlencoding::encode(&scopes),
@@ -179,15 +179,16 @@ pub async fn run(
                     config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
                 let tenant_id =
                     config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-                auth::device_code::authenticate(&client_id, &tenant_id, scopes.as_deref()).await?
+                let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
+                auth::device_code::authenticate(&client_id, &tenant_id, Some(&scopes)).await?
             } else {
                 // Default: auth code + PKCE
                 let client_id =
                     config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
                 let tenant_id =
                     config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-                auth::auth_code_pkce::authenticate(&client_id, &tenant_id, scopes.as_deref())
-                    .await?
+                let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
+                auth::auth_code_pkce::authenticate(&client_id, &tenant_id, Some(&scopes)).await?
             };
 
             let token_info = token_response.into_token_info(profile);
@@ -215,12 +216,13 @@ pub async fn run(
                 config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
             let tenant_id =
                 config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-            let url = delegated_admin_consent_url(&client_id, &tenant_id);
+            let scopes = config::resolve_delegated_scopes(None, profile, config);
+            let url = delegated_admin_consent_url(&client_id, &tenant_id, &scopes);
             let msg = serde_json::json!({
                 "admin_consent_url": url,
                 "client_id": client_id,
                 "tenant_id": tenant_id,
-                "scope": config::DEFAULT_DELEGATED_SCOPES,
+                "scope": scopes,
                 "redirect_uri": config::DEFAULT_REDIRECT_URI,
             });
             output::print_success(format, &msg, start);
@@ -245,7 +247,9 @@ pub async fn run(
             let token = auth::resolve_token(profile).await.ok();
             let claims = token.as_ref().and_then(|t| t.unverified_claims());
             let warnings = token_warnings(claims.as_ref());
-            let admin_consent_url = delegated_admin_consent_url(&client_id, &tenant_id);
+            let resolved_scopes = config::resolve_delegated_scopes(None, profile, config);
+            let admin_consent_url =
+                delegated_admin_consent_url(&client_id, &tenant_id, &resolved_scopes);
             let msg = serde_json::json!({
                 "profile": profile,
                 "auth_app": auth_app,
@@ -253,6 +257,7 @@ pub async fn run(
                 "tenant_id": tenant_id,
                 "admin_consent_url": admin_consent_url,
                 "default_delegated_scopes": config::DEFAULT_DELEGATED_SCOPES,
+                "resolved_delegated_scopes": resolved_scopes,
                 "redirect_uri": config::DEFAULT_REDIRECT_URI,
                 "authenticated": token.is_some(),
                 "warnings": warnings,

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,15 +251,17 @@ pub fn ensure_offline_access(scopes: &str) -> String {
     }
 }
 
-/// Resolve the delegated scope string: CLI flag or `TEAMS_CLI_SCOPES` env var
-/// (delivered via clap), then the profile's `scopes`, then the defaults.
-/// Blank values fall through so an empty env var cannot produce an empty
-/// OAuth scope request. Overrides always get `offline_access` appended.
-pub fn resolve_delegated_scopes(
+/// Resolve an explicitly configured delegated scope override: CLI flag or
+/// `TEAMS_CLI_SCOPES` env var (delivered via clap), then the profile's
+/// `scopes`. Returns `None` when neither is set so callers can pick their own
+/// fallback — login falls back to the defaults, refresh to the stored token's
+/// scope. Blank values fall through so an empty env var cannot produce an
+/// empty OAuth scope request. Overrides always get `offline_access` appended.
+pub fn resolve_delegated_scopes_override(
     scopes_arg: Option<&str>,
     profile: &str,
     config: &ConfigFile,
-) -> String {
+) -> Option<String> {
     let non_blank = |s: &str| {
         let trimmed = s.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
@@ -275,6 +277,16 @@ pub fn resolve_delegated_scopes(
                 .and_then(non_blank)
         })
         .map(|scopes| ensure_offline_access(&scopes))
+}
+
+/// Resolve the delegated scope string for login: the explicit override when
+/// set, otherwise the default delegated scopes.
+pub fn resolve_delegated_scopes(
+    scopes_arg: Option<&str>,
+    profile: &str,
+    config: &ConfigFile,
+) -> String {
+    resolve_delegated_scopes_override(scopes_arg, profile, config)
         .unwrap_or_else(|| DEFAULT_DELEGATED_SCOPES.to_string())
 }
 
@@ -476,6 +488,24 @@ scopes = "User.Read People.Read offline_access"
         assert_eq!(
             resolve_delegated_scopes(None, "default", &config),
             DEFAULT_DELEGATED_SCOPES
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_override_none_when_unset() {
+        let config = ConfigFile::default();
+        assert_eq!(
+            resolve_delegated_scopes_override(None, "default", &config),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_override_some_for_profile_value() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes_override(None, "work", &config).as_deref(),
+            Some("User.Read People.Read offline_access")
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ pub struct ProfileConfig {
     pub client_id: Option<String>,
     pub tenant_id: Option<String>,
     pub auth_flow: Option<String>,
+    pub scopes: Option<String>,
 }
 
 fn default_format() -> String {
@@ -239,6 +240,44 @@ pub fn resolve_delegated_tenant_id(
         .unwrap_or_else(|| DEFAULT_DELEGATED_TENANT_ID.to_string())
 }
 
+/// Append `offline_access` to a delegated scope string when it is missing, so
+/// the identity platform always issues a refresh token.
+pub fn ensure_offline_access(scopes: &str) -> String {
+    let trimmed = scopes.trim();
+    if trimmed.split_whitespace().any(|s| s == "offline_access") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed} offline_access")
+    }
+}
+
+/// Resolve the delegated scope string: CLI flag or `TEAMS_CLI_SCOPES` env var
+/// (delivered via clap), then the profile's `scopes`, then the defaults.
+/// Blank values fall through so an empty env var cannot produce an empty
+/// OAuth scope request. Overrides always get `offline_access` appended.
+pub fn resolve_delegated_scopes(
+    scopes_arg: Option<&str>,
+    profile: &str,
+    config: &ConfigFile,
+) -> String {
+    let non_blank = |s: &str| {
+        let trimmed = s.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
+
+    scopes_arg
+        .and_then(non_blank)
+        .or_else(|| {
+            config
+                .profiles
+                .get(profile)
+                .and_then(|p| p.scopes.as_deref())
+                .and_then(non_blank)
+        })
+        .map(|scopes| ensure_offline_access(&scopes))
+        .unwrap_or_else(|| DEFAULT_DELEGATED_SCOPES.to_string())
+}
+
 pub fn resolve_client_secret(cli_flag: Option<&str>) -> Option<String> {
     if let Some(v) = cli_flag {
         return Some(v.to_string());
@@ -321,6 +360,7 @@ max_retries = 5
 client_id = "abc-123"
 tenant_id = "tenant-456"
 auth_flow = "device-code"
+scopes = "User.Read People.Read offline_access"
 "#;
         let config: ConfigFile = toml::from_str(toml_str).unwrap();
         assert_eq!(config.default.profile.as_deref(), Some("work"));
@@ -334,6 +374,10 @@ auth_flow = "device-code"
         assert_eq!(work.client_id.as_deref(), Some("abc-123"));
         assert_eq!(work.tenant_id.as_deref(), Some("tenant-456"));
         assert_eq!(work.auth_flow.as_deref(), Some("device-code"));
+        assert_eq!(
+            work.scopes.as_deref(),
+            Some("User.Read People.Read offline_access")
+        );
     }
 
     #[test]
@@ -373,6 +417,7 @@ auth_flow = "device-code"
                 client_id: Some("from-config".into()),
                 tenant_id: None,
                 auth_flow: None,
+                scopes: None,
             },
         );
 
@@ -413,6 +458,69 @@ auth_flow = "device-code"
         assert!(!DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Read.All"));
     }
 
+    fn config_with_profile_scopes(scopes: Option<&str>) -> ConfigFile {
+        let mut config = ConfigFile::default();
+        config.profiles.insert(
+            "work".into(),
+            ProfileConfig {
+                scopes: scopes.map(|s| s.to_string()),
+                ..ProfileConfig::default()
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_defaults_when_unset() {
+        let config = ConfigFile::default();
+        assert_eq!(
+            resolve_delegated_scopes(None, "default", &config),
+            DEFAULT_DELEGATED_SCOPES
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_uses_profile_and_appends_offline_access() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(None, "work", &config),
+            "User.Read People.Read offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_preserves_existing_offline_access() {
+        let config = config_with_profile_scopes(Some("User.Read offline_access People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(None, "work", &config),
+            "User.Read offline_access People.Read"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_cli_value_beats_profile() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(Some("Chat.ReadWrite"), "work", &config),
+            "Chat.ReadWrite offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_blank_values_fall_through() {
+        let blank_profile = config_with_profile_scopes(Some("   "));
+        assert_eq!(
+            resolve_delegated_scopes(Some("  "), "work", &blank_profile),
+            DEFAULT_DELEGATED_SCOPES
+        );
+
+        let config = config_with_profile_scopes(Some("User.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(Some(""), "work", &config),
+            "User.Read offline_access"
+        );
+    }
+
     #[test]
     fn delegated_auth_byo_requires_client_id() {
         let mut config = ConfigFile::default();
@@ -423,6 +531,7 @@ auth_flow = "device-code"
                 client_id: None,
                 tenant_id: Some("tenant".into()),
                 auth_flow: Some("device-code".into()),
+                scopes: None,
             },
         );
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,7 @@ use std::fs;
 fn teams() -> Command {
     let mut cmd = Command::cargo_bin("teams").unwrap();
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
+    cmd.env_remove("TEAMS_CLI_SCOPES");
     cmd
 }
 
@@ -71,6 +72,65 @@ fn auth_consent_url_uses_oso_default_client_id() {
                 .and(predicate::str::contains("organizations"))
                 .and(predicate::str::contains("ChannelMessage.Read.All").not()),
         );
+}
+
+#[test]
+fn auth_login_help_documents_scopes_flag_and_env() {
+    teams()
+        .args(["auth", "login", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--scopes <SCOPES>")
+                .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_consent_url_uses_profile_scopes_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+scopes = "User.Read People.Read TeamMember.Read.All offline_access"
+"#,
+    )
+    .unwrap();
+
+    teams()
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "--profile",
+            "customer",
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("People.Read")
+                .and(predicate::str::contains("TeamMember.Read.All"))
+                .and(predicate::str::contains(
+                    "11111111-1111-1111-1111-111111111111",
+                )),
+        );
+}
+
+#[test]
+fn auth_doctor_reports_resolved_delegated_scopes() {
+    teams()
+        .args(["auth", "doctor", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"resolved_delegated_scopes\""));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,7 +6,14 @@ use std::fs;
 fn teams() -> Command {
     let mut cmd = Command::cargo_bin("teams").unwrap();
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
+    // Isolate tests from the developer's real environment: a configured
+    // profile or exported credentials would otherwise change command output.
+    cmd.env("HOME", std::env::temp_dir().join("teams-cli-test-home"));
     cmd.env_remove("TEAMS_CLI_SCOPES");
+    cmd.env_remove("TEAMS_CLI_CLIENT_ID");
+    cmd.env_remove("TEAMS_CLI_CLIENT_SECRET");
+    cmd.env_remove("TEAMS_CLI_TENANT_ID");
+    cmd.env_remove("TEAMS_CLI_ACCESS_TOKEN");
     cmd
 }
 
@@ -83,6 +90,54 @@ fn auth_login_help_documents_scopes_flag_and_env() {
         .stdout(
             predicate::str::contains("--scopes <SCOPES>")
                 .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_help_shows_refresh_subcommand() {
+    teams()
+        .args(["auth", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("refresh"));
+}
+
+#[test]
+fn auth_refresh_help_documents_scopes_flag_and_env() {
+    teams()
+        .args(["auth", "refresh", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--scopes <SCOPES>")
+                .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_refresh_without_login_fails_with_auth_error() {
+    teams()
+        .args(["auth", "refresh", "--output", "json"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains("auth login"));
+}
+
+#[test]
+fn auth_consent_url_accepts_explicit_scopes() {
+    teams()
+        .args([
+            "auth",
+            "consent-url",
+            "--scopes",
+            "User.Read People.Read",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("People.Read").and(predicate::str::contains("offline_access")),
         );
 }
 


### PR DESCRIPTION
Closes #33.

Two commits:

**feat(auth): support per-profile delegated scopes** — adds an optional `scopes` field to `[profiles.NAME]` so a profile can pin the delegated scope string requested at login. Resolution order matches the existing credential pattern: `--scopes` flag / new `TEAMS_CLI_SCOPES` env var → profile field → built-in defaults; blank values fall through, and `offline_access` is always ensured. `auth consent-url` and `auth doctor` now build their admin-consent URL from the *resolved* scopes (doctor also reports `resolved_delegated_scopes`), so the consent link always matches what login will request. The default scope set is unchanged and remains free of admin-consent-required permissions; client-credentials login is untouched.

**feat(auth): add auth refresh for silent scope upgrades** — adds `teams auth refresh`, which redeems the stored refresh token for the resolved scopes without interactive login. Refresh tokens are bound to the user and client rather than the originally requested scopes, so once new permissions are consented an existing session can pick them up silently — the same mechanism MSAL uses for incremental consent, with naming precedent from `gh auth refresh --scopes`. A plain refresh reuses the stored token's scope, so it never narrows a session. When the identity platform rejects unconsented scopes (AADSTS65001), the error is annotated with the exact `teams --profile <name> auth consent-url` command to fix it; `auth consent-url` gains the matching `--scopes` override. Unlike the best-effort background refresh, a keyring persistence failure after an explicit refresh is a hard error, since storing the upgraded token is the point of the command.

## Testing

- `cargo test --all-targets`: unit tests for scope resolution and the consent-error guidance; black-box CLI tests for the new flag surface, consent-url/doctor scope resolution, and the refresh-without-login error path. The CLI test helper now isolates `HOME` and credential env vars so a developer's real config or exported credentials can't change black-box results.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Live against a real Entra tenant: after a tenant admin consented new permissions (`Files.ReadWrite.All`, `People.Read`, `TeamMember.Read.All`), `teams auth refresh` silently upgraded the stored session — no browser — with the granted scopes confirmed in the command's JSON output. The AADSTS65001 path was also exercised live (before consent had propagated) and produced the annotated guidance with the correct `--profile` in the suggested consent-url command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dbE5zSCCZwn9Ao3hm5pg4
