### PR TITLE
test: isolate CLI tests from the developer config file

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,13 @@ use std::fs;
 fn teams() -> Command {
     let mut cmd = Command::cargo_bin("teams").unwrap();
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
+    // Point the platform config-directory lookup at cargo's temp dir so the
+    // developer's real config file can't leak into assertions about
+    // out-of-box defaults. dirs resolves via $HOME on macOS and
+    // $XDG_CONFIG_HOME on Linux; Windows uses the Known Folder API and is
+    // unaffected by these overrides.
+    cmd.env("HOME", env!("CARGO_TARGET_TMPDIR"));
+    cmd.env("XDG_CONFIG_HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd
 }
 


### PR DESCRIPTION
Closes #38.

The teams() test helper disabled the keyring but still let the binary load the developer's real config.toml, so the two tests asserting out-of-box defaults (OSO client ID in the consent URL, `auth_app: oso` from doctor) failed on any machine whose default profile uses a BYO app. Redirect HOME and XDG_CONFIG_HOME to cargo's temp dir in the helper so the config lookup finds nothing. All 44 CLI tests now pass on a machine with a customized config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9t7Fgaasci1xYAFHw6ysq