### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,28 @@
 
 ## Unreleased
 
+## v0.3.0 - 2026-07-09
+
 ### Added
 
+- Per-profile delegated scope configuration for auth flows, including `TEAMS_CLI_SCOPES`, `--scopes` overrides, and scope-aware admin consent URLs.
+- `teams auth refresh` for explicitly redeeming a stored refresh token and upgrading delegated scopes without forcing a full login when consent already exists.
+- `teams user resolve`, which resolves IDs, UPNs, email addresses, and names using exact `/users` lookup, People API candidates, and an optional chat-roster sweep.
 - `teams message attachments list` and `teams message attachments download`: read the images users paste into messages (Graph hosted contents), file attachments stored in SharePoint/OneDrive, and code snippets. `list` returns an indexed inventory; `download` saves items to disk (or stdout with `--path -`) and reports each file's path, size, and MIME type. Works for channel messages, channel thread replies (`--reply`), and chats (`--chat`). Inline images need no scopes beyond message reads; file attachments require the `Files.Read.All` delegated scope and fail with an actionable hint without it.
 - `teams message get --with-attachments` embeds the same attachment inventory in the message output under `attachment_items`.
 - `teams message send`/`reply` gained `--image` (send a picture inline, like pasting a screenshot — no scopes beyond message sends) and `--attach` (upload a file to OneDrive/SharePoint and attach it — needs `Files.ReadWrite` for chats or `Files.ReadWrite.All` for channels). Both repeat for multiple files; `--body` is optional when media is present. Scope failures explain which storage the upload targets, which scope it needs, and how to grant it; docs/attachments-spec.md carries the full hosted-contents-vs-files explainer.
 
 ### Fixed
 
+- CLI tests now isolate config-directory lookup from the developer's real machine config and scrub inherited auth environment variables.
+- `teams user resolve` now verifies People API hits through `/users/{userPrincipalName}` before returning a directory object ID, rather than treating the People resource ID as a Microsoft Entra user ID.
+- Attachment and inline-image parsing now accepts only Microsoft Graph hosted-content URLs for bearer-token downloads and rejects lookalike external URLs.
+- `teams message send --attach` now uses Microsoft Graph's 250MB simple-upload limit for DriveItem uploads instead of incorrectly applying the 4MB JSON request limit.
 - `teams message get` no longer silently drops the `contentUrl`, `thumbnailUrl`, and `teamsAppId` fields of message attachments, which made file attachments unresolvable from CLI output.
+
+### Changed
+
+- Refreshed the Rust dependency lockfile, including the `anyhow` advisory fix pulled in by the rust-minor dependency update.
 
 ## v0.2.8 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `teams message attachments list` and `teams message attachments download`: read the images users paste into messages (Graph hosted contents), file attachments stored in SharePoint/OneDrive, and code snippets. `list` returns an indexed inventory; `download` saves items to disk (or stdout with `--path -`) and reports each file's path, size, and MIME type. Works for channel messages, channel thread replies (`--reply`), and chats (`--chat`). Inline images need no scopes beyond message reads; file attachments require the `Files.Read.All` delegated scope and fail with an actionable hint without it.
 - `teams message get --with-attachments` embeds the same attachment inventory in the message output under `attachment_items`.
+- `teams message send`/`reply` gained `--image` (send a picture inline, like pasting a screenshot — no scopes beyond message sends) and `--attach` (upload a file to OneDrive/SharePoint and attach it — needs `Files.ReadWrite` for chats or `Files.ReadWrite.All` for channels). Both repeat for multiple files; `--body` is optional when media is present. Scope failures explain which storage the upload targets, which scope it needs, and how to grant it; docs/attachments-spec.md carries the full hosted-contents-vs-files explainer.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `teams message attachments list` and `teams message attachments download`: read the images users paste into messages (Graph hosted contents), file attachments stored in SharePoint/OneDrive, and code snippets. `list` returns an indexed inventory; `download` saves items to disk (or stdout with `--path -`) and reports each file's path, size, and MIME type. Works for channel messages, channel thread replies (`--reply`), and chats (`--chat`). Inline images need no scopes beyond message reads; file attachments require the `Files.Read.All` delegated scope and fail with an actionable hint without it.
+- `teams message get --with-attachments` embeds the same attachment inventory in the message output under `attachment_items`.
+
+### Fixed
+
+- `teams message get` no longer silently drops the `contentUrl`, `thumbnailUrl`, and `teamsAppId` fields of message attachments, which made file attachments unresolvable from CLI output.
+
 ## v0.2.8 - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Attachment and inline-image parsing now accepts only Microsoft Graph hosted-content URLs for bearer-token downloads and rejects lookalike external URLs.
 - `teams message send --attach` now uses Microsoft Graph's 250MB simple-upload limit for DriveItem uploads instead of incorrectly applying the 4MB JSON request limit.
 - `teams message get` no longer silently drops the `contentUrl`, `thumbnailUrl`, and `teamsAppId` fields of message attachments, which made file attachments unresolvable from CLI output.
+- `teams completions` now generates completions on a larger worker-thread stack so the expanded command tree does not overflow the default Windows stack.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,9 +49,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -177,9 +177,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
@@ -205,9 +205,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -241,18 +241,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -312,9 +312,9 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -779,9 +779,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -794,7 +794,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -986,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1218,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1344,12 +1343,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -1797,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2071,9 +2064,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2088,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2256,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2358,9 +2351,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2559,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.2.8"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -504,9 +504,10 @@ teams user resolve "jane smith" --max-chats 500
 
 `user resolve` turns a colleague reference into user-ID candidates, trying
 each lookup path the token's scopes allow and skipping past the ones that
-403: exact `/users/{q}` lookup (baseline scopes), people search (People.Read),
-and finally a sweep of shared group/meeting chat rosters (baseline scopes,
-bounded by `--max-chats`). An email query matches only the full address and
+403: exact `/users/{q}` lookup (baseline scopes), People API search
+(`People.Read`, verified back to `/users/{userPrincipalName}` before an object
+ID is returned), and finally a sweep of shared group/meeting chat rosters
+(baseline scopes, bounded by `--max-chats`). An email query matches only the full address and
 ends the sweep early; bare name or alias queries keep scanning to the bound
 so namesakes in other chats aren't silently missed. Ambiguous names return
 every match — candidates carry `jobTitle`/`department` where available to

--- a/README.md
+++ b/README.md
@@ -140,7 +140,15 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 ```
+
+The optional `scopes` field replaces the default delegated scope string for
+that profile, so a BYO app with admin-consented permissions (for example
+`People.Read` for people search) can request them on every login without
+passing `--scopes`. The value is used verbatim except that `offline_access` is
+appended when missing. The default scope set is unchanged for profiles that
+omit the field.
 
 Then sign in:
 
@@ -221,6 +229,10 @@ admin-consent required. Use `--scopes` or a customer-owned app when a workflow
 needs channel message reads.
 
 **Credential resolution order**: CLI flags > environment variables > config file profiles.
+
+Delegated scope resolution follows the same order: `--scopes` (or
+`TEAMS_CLI_SCOPES`), then the profile's `scopes` field, then the built-in
+default scope set.
 
 ### Why not import Teams client tokens?
 
@@ -546,6 +558,7 @@ auth_flow = "device-code"
 | `TEAMS_CLI_CLIENT_ID` | Azure AD application (client) ID |
 | `TEAMS_CLI_CLIENT_SECRET` | Azure AD client secret |
 | `TEAMS_CLI_TENANT_ID` | Azure AD tenant ID |
+| `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login (same precedence as `--scopes`; ignored by client credentials) |
 | `TEAMS_CLI_ACCESS_TOKEN` | Pre-obtained Microsoft Graph access token (skips login entirely) |
 | `RUST_LOG` | Tracing filter (e.g., `debug`, `teams=trace`) |
 

--- a/README.md
+++ b/README.md
@@ -498,7 +498,23 @@ teams listen --port 8080
 teams user me
 teams user get <user-id-or-upn>
 teams user list
+teams user resolve <name-or-email>            # scope-aware candidate search
+teams user resolve "jane smith" --max-chats 500
 ```
+
+`user resolve` turns a colleague reference into user-ID candidates, trying
+each lookup path the token's scopes allow and skipping past the ones that
+403: exact `/users/{q}` lookup (baseline scopes), people search (People.Read),
+and finally a sweep of shared group/meeting chat rosters (baseline scopes,
+bounded by `--max-chats`). An email query matches only the full address and
+ends the sweep early; bare name or alias queries keep scanning to the bound
+so namesakes in other chats aren't silently missed. Ambiguous names return
+every match — candidates carry `jobTitle`/`department` where available to
+tell namesakes apart, plus a `via` field (`upn` | `people-search` | `roster`)
+so callers can judge match confidence, and a `stages` report shows what was
+attempted, including a `skippedChats` count when unreadable rosters made the
+sweep incomplete. A degraded Graph (rate limiting, 5xx) aborts with that
+error rather than reporting a false miss. No candidates means exit code 5.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ Delegated scope resolution follows the same order: `--scopes` (or
 `TEAMS_CLI_SCOPES`), then the profile's `scopes` field, then the built-in
 default scope set.
 
+When permissions are consented after login (for example an admin grants a new
+delegated scope), `teams auth refresh` silently redeems the stored refresh
+token for the resolved scopes — no browser or device code. Refresh tokens are
+bound to the user and client, not to the originally requested scopes, so the
+upgrade succeeds for any scope set already consented for the app. Without an
+explicit override the stored token's scope is reused, so a plain refresh never
+narrows a session. If consent is missing, the identity platform rejects the
+request and the CLI prints the matching `consent-url` command to fix it.
+
 ### Why not import Teams client tokens?
 
 Tools such as `fossteams/teams-token` are attractive because they avoid Entra
@@ -312,6 +321,7 @@ esac
 teams auth login             # Interactive login (browser)
 teams auth login --device-code  # Device code flow
 teams auth login --client-credentials  # App-only Graph operations where supported
+teams auth refresh           # Silently redeem the refresh token (picks up newly consented scopes)
 teams auth status            # Check if session is valid (exit code 0/1)
 teams auth consent-url       # Print admin consent URL for the active auth app
 teams auth doctor            # Diagnose config and token state

--- a/docs/attachments-spec.md
+++ b/docs/attachments-spec.md
@@ -1,0 +1,285 @@
+# Specification: Reading Message Attachments and Inline Images
+
+Status: draft
+Date: 2026-07-08
+Branch target: follow-up to `feat/profile-scopes`
+
+## Problem
+
+Users routinely paste screenshots into Teams messages. `teams message get` returns the
+message body verbatim, but the screenshot itself is unreachable through the CLI. Agents
+and scripts consuming the JSON envelope see an `<img>` tag they cannot fetch, because the
+image bytes sit behind an authenticated Microsoft Graph endpoint.
+
+Two distinct mechanisms are involved, and the CLI currently supports neither:
+
+### 1. Inline images — `hostedContents` (the screenshot case)
+
+When a user pastes or drags an image directly into the compose box, Teams stores it as a
+`chatMessageHostedContent`. The message body HTML references it by an authenticated Graph
+URL:
+
+```html
+<img src="https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/messages/{message-id}/hostedContents/{hosted-content-id}/$value"
+     width="410" height="204" alt="image" itemid="0-frca-d14-...">
+```
+
+Verified against a live message (team `5c42feaf`, channel `19:b8fe94da...@thread.skype`,
+message `1783503421261`):
+
+- `GET .../messages/{id}/hostedContents` lists items but returns `contentBytes: null` and
+  `contentType: null` — metadata only. Bytes require a per-item call.
+- `GET .../hostedContents/{hosted-content-id}/$value` returns the raw bytes
+  (`200`, `image/png`, correct pixels) **using the token the CLI already holds**.
+  `ChannelMessage.Read.All` (channels) / `Chat.ReadWrite` or `ChatMessage.Read` (chats)
+  suffice. No new scopes required.
+- The hosted-content ID is base64 and decodes to
+  `id=x_...,type=1,url=https://eu-api.asm.skype.com/v1/objects/...` — an internal Skype
+  asset pointer. Treat it as opaque; always fetch through Graph, never the ASM URL.
+
+So the screenshot case is purely a missing-feature problem: the CLI never calls these
+endpoints and gives callers no way to do so.
+
+### 2. File attachments — `attachments[]` with `contentType: "reference"`
+
+Files attached via the paperclip (or drag-dropped as files rather than pasted as pixels)
+appear in the message's `attachments` array pointing at SharePoint/OneDrive:
+
+```json
+{
+  "id": "C0F75B79-7D00-4DC9-918F-5FAEDD1086A4",
+  "contentType": "reference",
+  "contentUrl": "https://{tenant}-my.sharepoint.com/personal/{user}/Documents/Microsoft%20Teams%20Chat%20Files/NetskopeLogs.zip",
+  "name": "NetskopeLogs.zip"
+}
+```
+
+Two defects here:
+
+- **The CLI silently drops `contentUrl`.** `ChatMessageAttachment` in
+  `src/models/message.rs` has no `content_url` field, so even the pointer to the file is
+  lost from `message get` output.
+- **No download path.** The canonical way to download is Graph's sharing-URL resolver:
+  base64url-encode the `contentUrl`, prefix `u!`, strip padding, then
+  `GET /shares/{token}/driveItem/content`. Verified live: this returns **403
+  `accessDenied` with current scopes** — it requires `Files.Read.All` (delegated).
+  This is exactly the per-profile scope-upgrade case `feat/profile-scopes` was built for.
+
+### Other attachment content types (in scope for parsing, out of scope for download)
+
+- `application/vnd.microsoft.card.*` — adaptive/hero cards; `content` is inline JSON.
+- `messageReference` — quoted replies; `content` is inline JSON.
+- `application/vnd.microsoft.card.codesnippet` — code snippets; the attachment `content`
+  JSON carries a `codeSnippetUrl` that resolves to a hostedContent, fetched via the same
+  authenticated `/$value` mechanism as images. Worth including in the download path (it
+  is text an agent wants to read), unlike cards.
+
+## Prior art
+
+Every serious open-source exporter/bridge converges on the same two-track approach this
+spec proposes; none of them expose it as a composable CLI primitive, which is our gap to
+fill.
+
+- **[teams-chats-export](https://github.com/codeforkjeff/teams-chats-export)** (Python,
+  Graph SDK) — the cleanest reference. Does not trust the `hostedContents` collection
+  (bytes are always null there); instead regexes the body HTML for
+  `src="...graph.microsoft.com/.../hostedContents/{id}/$value"` and GETs each with the
+  bearer token. Also resolves code-snippet attachments to their hosted content. Handles
+  per-item access failures with try/except. Delegated `Chat.Read`.
+- **[matterbridge msteams bridge](https://github.com/42wim/matterbridge/pull/967)** (Go)
+  — file attachments via the shares trick: `GetDriveItemByURL(contentUrl)` →
+  `@microsoft.graph.downloadUrl` → plain HTTP download. Special-cases
+  `application/vnd.microsoft.card.codesnippet` (parses `codeSnippetUrl` from attachment
+  `content` JSON, fetches authenticated, wraps in a fenced code block). Never implemented
+  inline pasted images.
+- **[m365 CLI](https://github.com/pnp/cli-microsoft365)** (`m365 teams message get`) —
+  prints raw message JSON only; downloading hosted content or resolving `reference`
+  attachments is left entirely to the caller. This is where teams-cli sits today.
+- **[Export-TeamsChat](https://github.com/mardahl/Export-TeamsChat)** (PowerShell) —
+  downloads inline images to a sibling assets folder and rewrites the HTML `src` to local
+  relative paths; explicitly does not download `reference` file attachments.
+- **[teams-chat-backup](https://github.com/edgraaff/teams-chat-backup)** (Node) and
+  similar exporters — paginate messages, save `image-#####` files, render local HTML.
+
+Cross-project lessons the design below absorbs:
+
+- The `<img src>` in body HTML is the source of truth for inline images; the
+  `hostedContents` collection is only good for enumeration.
+- The `/$value` response's `Content-Type` header is the only reliable MIME source for
+  hosted contents; `driveItem.file.mimeType` is the equivalent for file references.
+- The top failure modes in the wild are (a) reading `contentBytes` from the collection
+  and getting nulls, (b) 404s from mis-encoding `contentUrl` (spaces, trailing slashes)
+  before base64url, and (c) 403s from missing `Files.Read.All` silently swallowed by SDK
+  wrappers. All three get explicit tests.
+- Per-message reads (`GET .../messages/{id}`, `hostedContents/$value`, `/shares/...`)
+  are ordinary non-metered Graph calls. Only the bulk export APIs (`getAllMessages`)
+  ever required metered billing, and Microsoft removed that metering in August 2025 —
+  irrelevant to this feature either way.
+- No prior art exists for agent-native consumption (manifest of local paths + MIME
+  types); every tool stops at "bytes on disk." The inventory/manifest design below is
+  the differentiator.
+
+## Design
+
+### Goals
+
+- An agent holding only the CLI can go from a message link/ID to readable image bytes on
+  disk in one command.
+- `message get` output becomes self-describing: attachments and inline images are
+  enumerated with stable indices so callers can request downloads without parsing HTML.
+- Follow existing patterns: JSON envelope, exit codes, `endpoints.rs` URL builders,
+  `GraphClient::get_bytes`, `file download`'s `--path`/stdout convention.
+
+### Non-goals
+
+- Uploading inline images (send-side hostedContents) — separate feature.
+- Rendering images in the terminal (sixel/kitty) — the consumer is usually an agent or a
+  file; a path on disk is the right interface.
+- OCR — leave interpretation to the caller.
+
+### CLI surface
+
+One new subcommand group plus one convenience flag.
+
+#### `teams message attachments list`
+
+```
+teams message attachments list --team <TEAM> --channel <CHANNEL> <MESSAGE_ID>
+teams message attachments list --chat <CHAT> <MESSAGE_ID>
+```
+
+Returns a unified inventory of everything downloadable in the message, merging both
+mechanisms:
+
+```json
+{
+  "success": true,
+  "data": {
+    "message_id": "1783503421261",
+    "items": [
+      {
+        "index": 0,
+        "kind": "hosted_content",
+        "hosted_content_id": "aWQ9...",
+        "content_type": "image/png",
+        "alt": "image",
+        "width": 410,
+        "height": 204
+      },
+      {
+        "index": 1,
+        "kind": "file_reference",
+        "attachment_id": "C0F75B79-...",
+        "name": "NetskopeLogs.zip",
+        "content_url": "https://...sharepoint.com/.../NetskopeLogs.zip"
+      }
+    ]
+  }
+}
+```
+
+`hosted_content` entries are discovered from `GET .../hostedContents` and enriched
+(dimensions, alt text) by parsing `<img>` tags in the body HTML whose `src` matches the
+hostedContents URL pattern. `content_type` for hosted contents is only known after a
+byte fetch (the list endpoint returns null), so it is populated via sniffing on download
+and omitted in `list` output if unknown.
+
+#### `teams message attachments download`
+
+```
+teams message attachments download --team <TEAM> --channel <CHANNEL> <MESSAGE_ID> \
+    [--index <N> | --all] [--dir <DIR> | --path <FILE>]
+```
+
+- `--all` (default when neither `--index` nor `--path` given): downloads every item into
+  `--dir` (default `.`), naming files `msg-{message_id}-{index}.{ext}` for hosted
+  contents (extension from sniffed MIME type) and the attachment's `name` for file
+  references (collision-suffixed).
+- `--index N --path FILE` downloads a single item to an exact path; `--path -` streams
+  bytes to stdout (mirrors `file download`).
+- Hosted contents: `GET .../hostedContents/{id}/$value` via `GraphClient::get_bytes`.
+- File references: encode `contentUrl` → `GET /shares/u!{b64url}/driveItem` to resolve
+  metadata, then `/driveItem/content` for bytes (follows the 302 to a pre-authenticated
+  download URL).
+- JSON envelope reports one entry per item: `{index, kind, path, size, content_type}`,
+  with per-item `error` fields on partial failure (envelope `success: false` if any item
+  failed; exit code from the first error, e.g. 4 on 403).
+
+#### `teams message get --with-attachments`
+
+Convenience flag that inlines the `attachments list` inventory into the message envelope
+under `data.attachment_items`, so agents can decide in one round-trip whether a download
+pass is needed. Without the flag, `message get` output is unchanged **except** that the
+attachment model now carries `contentUrl` (bug fix, additive).
+
+### Implementation plan
+
+Ordered, each step compiles and passes tests independently.
+
+1. **Model fix** (`src/models/message.rs`): add `content_url`, `thumbnail_url`,
+   `teams_app_id` to `ChatMessageAttachment`. Add `ChatMessageHostedContent` model
+   (`id`, `contentBytes`, `contentType`). Unit-test round-trips.
+2. **Endpoints** (`src/api/endpoints.rs`): `channel_message_hosted_contents`,
+   `chat_message_hosted_contents`, `hosted_content_value` (channel + chat variants),
+   `shares_drive_item(token)`, `shares_drive_item_content(token)`. Add a
+   `sharing_url_token(url) -> String` helper (u! + base64url, no padding) with tests.
+3. **API layer** (`src/api/messages.rs` or new `src/api/hosted_contents.rs`):
+   `list_hosted_contents`, `get_hosted_content_bytes`, `resolve_shared_item`,
+   `download_shared_item`. Reuse `GraphClient::get_bytes` (already handles retry and
+   auth; verify it follows the SharePoint 302 redirect — reqwest does by default, but
+   confirm the Authorization header is not forwarded cross-origin, or strip it).
+4. **Inventory builder** (new `src/models/attachment_inventory.rs` or in `cli/message.rs`):
+   pure function `build_inventory(&ChatMessage, hosted: &[ChatMessageHostedContent]) -> Vec<Item>`;
+   parses body HTML for `<img src=".../hostedContents/{id}/$value">` to join dimensions
+   and ordering. Use a lightweight regex on the known URL shape rather than an HTML
+   parser dependency; unit-test against captured real payloads.
+5. **CLI wiring** (`src/cli/message.rs`): `MessageCommand::Attachments { List, Download }`
+   and the `--with-attachments` flag, following the `file download` handler's
+   path/stdout/envelope conventions.
+6. **MIME detection**: the `/$value` response's `Content-Type` header is the only
+   reliable MIME source for hosted contents — add a
+   `GraphClient::get_bytes_with_content_type` variant (or change `get_bytes` to return
+   `(Vec<u8>, Option<String>)`) rather than sniffing magic bytes. For file references,
+   take `driveItem.file.mimeType` from the `/shares/{token}/driveItem` resolution. Fall
+   back to magic-byte sniffing only if the header is absent.
+7. **Scope prerequisites**: hosted contents need nothing new. File references need
+   `Files.Read.All` delegated — document in `docs/auth.md` and add to the recommended
+   profile scope set so the `feat/profile-scopes` silent-upgrade flow picks it up. On
+   403 from `/shares`, the error message must say: add `Files.Read.All` to the profile
+   scopes and run `teams auth refresh`.
+8. **Docs + skill**: update `docs/command-reference.md`, `docs/examples.md`, and the
+   `teams-cli` agent skill so agents learn the pattern: `message get` → see
+   `attachment_items` → `attachments download --dir`.
+9. **Tests**: unit tests per step; integration tests (feature `integration`) that list
+   and download hosted contents from a known message; a wiremock-style test for the 403
+   scope-error message if the client tests already use a mock server (they do —
+   `src/api/client.rs` test module).
+
+### Error handling
+
+- 403 on `/shares` → exit code 4 with the actionable scope message above.
+- 404 on hostedContent (expired/deleted) → exit 5, name the index and message ID.
+- Partial `--all` failures download what they can and report per-item errors; non-zero
+  exit.
+- Never write partial files: download to `{path}.part`, rename on success.
+
+### Security notes
+
+- Hosted-content bytes are fetched only via `graph.microsoft.com`; the embedded ASM
+  (`asm.skype.com`) URLs inside decoded IDs are never contacted.
+- Downloaded filenames derived from attachment `name` must be sanitized (strip path
+  separators, `..`) before writing into `--dir`.
+- Bearer token must not leak into logs at `-vvv`; reuse existing redaction.
+
+## Resolved questions
+
+- Code snippets: downloadable like images (`kind: "code_snippet"`, extension from the
+  snippet's declared language). Cards: their JSON is already inline in the message
+  envelope; `list` surfaces them as `kind: "card"` with no download action, except that
+  image URLs inside card JSON are listed so callers can fetch CDN-hosted ones themselves.
+- Chat (1:1/group) parity: same `hostedContents` endpoints exist under
+  `/chats/{id}/messages/{id}`; delegated `Chat.Read`/`Chat.ReadWrite` suffices (already
+  in the default profile). Covered by integration tests.
+- Reply messages: hosted contents also hang off
+  `.../messages/{id}/replies/{reply-id}/hostedContents`; the endpoints module needs the
+  reply variant since screenshots very often appear in thread replies.

--- a/docs/attachments-spec.md
+++ b/docs/attachments-spec.md
@@ -188,22 +188,24 @@ and omitted in `list` output if unknown.
 
 ```
 teams message attachments download --team <TEAM> --channel <CHANNEL> <MESSAGE_ID> \
-    [--index <N> | --all] [--dir <DIR> | --path <FILE>]
+    [--index <N>] [--dir <DIR> | --path <FILE>]
 ```
 
-- `--all` (default when neither `--index` nor `--path` given): downloads every item into
-  `--dir` (default `.`), naming files `msg-{message_id}-{index}.{ext}` for hosted
-  contents (extension from sniffed MIME type) and the attachment's `name` for file
-  references (collision-suffixed).
-- `--index N --path FILE` downloads a single item to an exact path; `--path -` streams
-  bytes to stdout (mirrors `file download`).
-- Hosted contents: `GET .../hostedContents/{id}/$value` via `GraphClient::get_bytes`.
-- File references: encode `contentUrl` → `GET /shares/u!{b64url}/driveItem` to resolve
-  metadata, then `/driveItem/content` for bytes (follows the 302 to a pre-authenticated
-  download URL).
-- JSON envelope reports one entry per item: `{index, kind, path, size, content_type}`,
-  with per-item `error` fields on partial failure (envelope `success: false` if any item
-  failed; exit code from the first error, e.g. 4 on 403).
+- Default (no `--index`): downloads every downloadable item into `--dir` (default `.`),
+  naming files `msg-{message_id}-{index}.{ext}` for hosted contents (extension from the
+  `/$value` response's Content-Type header) and the attachment's sanitized `name` for
+  file references (collision-suffixed).
+- `--index N` downloads a single item; `--path FILE` (requires `--index`) sets an exact
+  destination, and `--path -` streams bytes to stdout (mirrors `file download`).
+- Hosted contents: `GET .../hostedContents/{id}/$value` via
+  `GraphClient::get_bytes_with_content_type`.
+- File references: encode `contentUrl` → `GET /shares/u!{b64url}/driveItem/content`
+  (follows the 302 to a pre-authenticated download URL; MIME type from the response
+  header).
+- On success the JSON envelope reports one entry per item:
+  `{index, kind, path, size, content_type}`. On any failure the command keeps
+  downloading what it can, then exits with the first error's code (e.g. 4 on 403) and
+  an error message naming the failed item and listing paths already saved.
 
 #### `teams message get --with-attachments`
 
@@ -219,15 +221,14 @@ Ordered, each step compiles and passes tests independently.
 1. **Model fix** (`src/models/message.rs`): add `content_url`, `thumbnail_url`,
    `teams_app_id` to `ChatMessageAttachment`. Add `ChatMessageHostedContent` model
    (`id`, `contentBytes`, `contentType`). Unit-test round-trips.
-2. **Endpoints** (`src/api/endpoints.rs`): `channel_message_hosted_contents`,
-   `chat_message_hosted_contents`, `hosted_content_value` (channel + chat variants),
-   `shares_drive_item(token)`, `shares_drive_item_content(token)`. Add a
-   `sharing_url_token(url) -> String` helper (u! + base64url, no padding) with tests.
-3. **API layer** (`src/api/messages.rs` or new `src/api/hosted_contents.rs`):
-   `list_hosted_contents`, `get_hosted_content_bytes`, `resolve_shared_item`,
-   `download_shared_item`. Reuse `GraphClient::get_bytes` (already handles retry and
-   auth; verify it follows the SharePoint 302 redirect — reqwest does by default, but
-   confirm the Authorization header is not forwarded cross-origin, or strip it).
+2. **Endpoints** (`src/api/endpoints.rs`): hostedContents list + `$value` URL builders
+   for channel, channel-reply, and chat scopes; `shares_drive_item_content(token)`; and
+   a `sharing_url_token(url) -> String` helper (u! + base64url, no padding) with tests.
+3. **API layer** (`src/api/messages.rs`): a `MessageRef` enum (channel / channel-reply /
+   chat) with `get_message`, `list_hosted_contents`, `get_hosted_content_bytes`;
+   `download_shared_item` in `src/api/files.rs`. Reuses the `GraphClient` retry
+   machinery; reqwest follows the SharePoint 302 and strips the Authorization header
+   cross-origin (same path the existing `file download` relies on).
 4. **Inventory builder** (new `src/models/attachment_inventory.rs` or in `cli/message.rs`):
    pure function `build_inventory(&ChatMessage, hosted: &[ChatMessageHostedContent]) -> Vec<Item>`;
    parses body HTML for `<img src=".../hostedContents/{id}/$value">` to join dimensions
@@ -259,8 +260,8 @@ Ordered, each step compiles and passes tests independently.
 
 - 403 on `/shares` → exit code 4 with the actionable scope message above.
 - 404 on hostedContent (expired/deleted) → exit 5, name the index and message ID.
-- Partial `--all` failures download what they can and report per-item errors; non-zero
-  exit.
+- Partial failures download what they can, then exit non-zero with an error that names
+  the failed item and lists the paths already saved.
 - Never write partial files: download to `{path}.part`, rename on success.
 
 ### Security notes
@@ -273,10 +274,11 @@ Ordered, each step compiles and passes tests independently.
 
 ## Resolved questions
 
-- Code snippets: downloadable like images (`kind: "code_snippet"`, extension from the
-  snippet's declared language). Cards: their JSON is already inline in the message
-  envelope; `list` surfaces them as `kind: "card"` with no download action, except that
-  image URLs inside card JSON are listed so callers can fetch CDN-hosted ones themselves.
+- Code snippets: downloadable like images (`kind: "code_snippet"`, saved as `.txt`,
+  declared `language` included in the inventory entry). Cards: their JSON is already
+  inline in the message envelope; `list` surfaces them as `kind: "card"` with
+  `downloadable: false`. Extracting image URLs from inside card JSON is left to
+  callers — the heuristics are too fuzzy to bake in.
 - Chat (1:1/group) parity: same `hostedContents` endpoints exist under
   `/chats/{id}/messages/{id}`; delegated `Chat.Read`/`Chat.ReadWrite` suffices (already
   in the default profile). Covered by integration tests.

--- a/docs/attachments-spec.md
+++ b/docs/attachments-spec.md
@@ -1,8 +1,15 @@
-# Specification: Reading Message Attachments and Inline Images
+# Specification: Message Attachments and Inline Images (Read and Send)
 
-Status: draft
+Status: Part I (read) implemented; Part II (send) in progress
 Date: 2026-07-08
 Branch target: follow-up to `feat/profile-scopes`
+
+Part I covers reading what other people put in messages; Part II covers sending.
+The [attachments for humans](#attachments-for-humans-hosted-contents-vs-files-and-the-scopes-they-need)
+section explains the two storage mechanisms and their OAuth scopes without assuming
+familiarity with Teams internals — start there if `hostedContents` means nothing to you.
+
+# Part I: Reading
 
 ## Problem
 
@@ -132,7 +139,7 @@ Cross-project lessons the design below absorbs:
 
 ### Non-goals
 
-- Uploading inline images (send-side hostedContents) — separate feature.
+- Uploading inline images (send-side hostedContents) — Part II below.
 - Rendering images in the terminal (sixel/kitty) — the consumer is usually an agent or a
   file; a path on disk is the right interface.
 - OCR — leave interpretation to the caller.
@@ -285,3 +292,159 @@ Ordered, each step compiles and passes tests independently.
 - Reply messages: hosted contents also hang off
   `.../messages/{id}/replies/{reply-id}/hostedContents`; the endpoints module needs the
   reply variant since screenshots very often appear in thread replies.
+
+# Attachments for humans: hosted contents vs. files, and the scopes they need
+
+Teams has two completely different storage mechanisms hiding behind what looks like one
+"add an image to my message" experience, and Microsoft's OAuth scopes track the storage,
+not the user gesture. Understanding this split explains every scope requirement in this
+feature.
+
+## The two mechanisms
+
+**Pasted screenshots ("hosted contents").** When you paste or drag an image *into the
+text of a message*, the image does not become a file anywhere you can browse. Teams
+stores the bytes as a blob glued to the message itself — Microsoft calls this a *hosted
+content*. It lives and dies with the message, has no filename, and is reachable only
+*through* the message. Because it travels inside the message, reading or sending it
+needs only message permissions — no file permissions at all.
+
+**Attached files ("reference attachments").** When you attach a file with the paperclip,
+Teams uploads the file to real, browsable storage and the message merely carries a link:
+
+- in a **channel**, the file lands in the team's SharePoint document library (the Files
+  tab you can open in a browser);
+- in a **chat**, the file lands in *the sender's own OneDrive*, in a folder called
+  `Microsoft Teams Chat Files`.
+
+The message's attachment entry is just `{name, contentUrl}` pointing at that storage.
+So touching these files means touching SharePoint/OneDrive, and Microsoft treats "send
+messages" and "read or write files in drives" as different doors with different keys.
+
+## The scope table
+
+Delegated scopes, per operation:
+
+| Operation | CLI command | Message scope | File scope needed | Why |
+|---|---|---|---|---|
+| Read a pasted screenshot | `message attachments download` | `ChatMessage.Read` / `ChannelMessage.Read.All` | none | bytes come through the message (`hostedContents/$value`) |
+| Send a pasted screenshot | `message send --image` | `ChatMessage.Send` / `ChannelMessage.Send` | none | bytes travel inside the message create call |
+| Download an attached file | `message attachments download` | (same as reading the message) | `Files.Read.All` | the file lives in someone's OneDrive / a team's SharePoint; reading it is a drive read |
+| Attach a file to a chat message | `message send --attach --chat` | `ChatMessage.Send` | `Files.ReadWrite` | the CLI must first upload the file into *your* OneDrive (`Microsoft Teams Chat Files`) |
+| Attach a file to a channel message | `message send --attach --team/--channel` | `ChannelMessage.Send` | `Files.ReadWrite.All` | the CLI must first upload into the *team's* SharePoint library, which is not your drive — hence the broader `.All` |
+
+Two consequences worth internalizing:
+
+- `--image` works with the CLI's default scopes. If you only ever send screenshots, you
+  never need a Files grant.
+- `--attach` is really two operations — a drive upload followed by a message send — and
+  the failure you hit without the Files scope happens at the *upload* step, before any
+  message exists.
+
+To add a scope: put it in the profile's `scopes` field in `config.toml`, then run
+`teams auth refresh` (silent, no browser; see docs/auth.md). Scopes marked `.All` may
+require a tenant admin's consent.
+
+# Part II: Sending
+
+## Problem
+
+The read side (Part I) lets agents see screenshots and files in messages. The mirror
+gesture — "send this screenshot / attach this file" — was still impossible: `message
+send` supports only text/HTML bodies and adaptive cards, and `file upload` puts a file
+in a channel's Files tab without attaching it to any message (and cannot touch chats).
+
+## Design
+
+### CLI surface
+
+```
+teams message send  (--team T --channel C | --chat CH) [--body TEXT | --stdin] \
+    [--image PATH]... [--attach PATH]...
+teams message reply --team T --channel C --message-id M [--body TEXT | --stdin] \
+    [--image PATH]... [--attach PATH]...
+```
+
+- `--image PATH` (repeatable): sends the file as a *hosted content* — the pasted-
+  screenshot experience. The message body gains an `<img>` per image. MIME type is
+  guessed from the file extension and must be an image type.
+- `--attach PATH` (repeatable): uploads the file to the correct drive for the target
+  (sender's OneDrive `Microsoft Teams Chat Files` for chats, the channel's folder in
+  the team's SharePoint library for channels), then references it from the message.
+  Uploads use `@microsoft.graph.conflictBehavior=rename` so an existing file with the
+  same name is never overwritten.
+- `--body` becomes optional when at least one `--image`/`--attach` is given.
+- Media forces the body content type to HTML; a plain-text `--body` is HTML-escaped
+  and wrapped in `<p>` first.
+
+### Graph mechanics
+
+**Inline images** ride the message create call itself. The request gains a
+`hostedContents` array; each item carries the base64 bytes and a temporary ID that the
+body references *relatively*:
+
+```json
+{
+  "body": {
+    "contentType": "html",
+    "content": "<p>look:</p><p><img src=\"../hostedContents/1/$value\"></p>"
+  },
+  "hostedContents": [{
+    "@microsoft.graph.temporaryId": "1",
+    "contentBytes": "iVBORw0KGgo...",
+    "contentType": "image/png"
+  }]
+}
+```
+
+Graph rewrites the relative `src` into a permanent hosted-content URL on delivery.
+Application (app-only) tokens cannot send hosted contents; the CLI already requires
+delegated auth for all message mutation, so nothing changes.
+
+**File attachments** are a two-step dance:
+
+1. `PUT` the bytes into the right drive (chat → `/me/drive/root:/Microsoft Teams Chat
+   Files/{name}:/content`, channel → the team drive folder that `filesFolder` reports,
+   same as `file upload`). The response is a `driveItem`.
+2. Send the message with an `attachments` entry whose `id` is **the GUID inside the
+   driveItem's `eTag`** (e.g. `"{5FF69C5F-...},2"` → `5FF69C5F-...`), `contentType`
+   `"reference"`, `contentUrl` = the driveItem's `webUrl`, `name` = its `name` — plus
+   an `<attachment id="{guid}"></attachment>` tag in the body HTML, which is what makes
+   the attachment card render in clients.
+
+Simple upload caps at 4&nbsp;MB (the existing `MAX_UPLOAD_SIZE`); larger files need the
+upload-session API, which is out of scope here — the CLI errors clearly instead.
+Hosted contents ride a single JSON request, so images are capped at 3&nbsp;MB each to
+stay under Graph's 4&nbsp;MB request limit after base64 expansion (+33%).
+
+### Error UX (scope failures must teach)
+
+A 403 — or a 404, since Graph masks drives the token cannot see as `itemNotFound`
+rather than `accessDenied` (verified live: `GET /me/drive` without any Files scope
+returns 404) — on the upload step returns the abbreviated version of the scope table
+above, tailored to the target:
+
+- chat: "Attaching files to chat messages uploads them to your OneDrive ('Microsoft
+  Teams Chat Files') first — that needs the `Files.ReadWrite` delegated scope, which
+  your token doesn't have. Inline images (`--image`) don't need it. Add the scope to
+  your profile's `scopes` and run `teams auth refresh`."
+- channel: same shape, naming the team's SharePoint library and `Files.ReadWrite.All`.
+
+Both point at docs/auth.md for the long version.
+
+### Implementation plan
+
+1. **Models**: `SendMessageRequest` gains `hostedContents`; new `HostedContentUpload`
+   (`@microsoft.graph.temporaryId`, `contentBytes`, `contentType`); `DriveItem` gains
+   `eTag`.
+2. **Endpoints**: chat-files upload URL under `/me/drive`, and a rename-on-conflict
+   variant of the channel folder upload.
+3. **API layer** (`src/api/files.rs`): `upload_chat_file`, `upload_channel_attachment`
+   (rename semantics), both with the teaching 403 hints.
+4. **CLI** (`src/cli/message_media.rs`): pure builders for the img/attachment HTML and
+   the eTag-GUID extraction (unit-tested), plus the async assembly that reads files,
+   guesses MIME types, enforces size caps, uploads, and extends `SendMessageRequest`.
+5. **Docs**: command-reference, examples, auth.md scope list, man page, CHANGELOG.
+6. **Verification**: live `--image` send with default scopes (must succeed); live
+   `--attach` without a Files grant (must fail with the teaching hint); unit tests for
+   builders and escaping.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -138,6 +138,25 @@ explicit opt-in for BYO app registrations. Do not use
 every permission configured on the app registration instead of the explicit
 scope list.
 
+## Upgrading scopes without re-login
+
+Refresh tokens are bound to the user and client, not to the scopes originally
+requested, so an existing session can be upgraded to newly consented
+permissions silently — the same mechanism MSAL uses for incremental consent:
+
+```bash
+teams auth consent-url --scopes "User.Read People.Read offline_access"  # admin grants once
+teams auth refresh                                                      # silent upgrade, no browser
+```
+
+`auth refresh` redeems the stored refresh token for the resolved scope string
+(`--scopes`/`TEAMS_CLI_SCOPES`, then profile `scopes`). Without an explicit
+override it reuses the stored token's scope, so a plain refresh never narrows
+an existing session. If a requested scope has not been consented, the
+identity platform rejects the whole request (AADSTS65001) rather than issuing
+a narrower token; the CLI then prints the exact `consent-url` command to
+grant it, or fall back to `teams auth login` for interactive consent.
+
 Customer-owned delegated app:
 
 ```bash

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -115,6 +115,29 @@ Custom scopes:
 teams auth login --device-code --scopes "User.Read ChatMessage.Send offline_access"
 ```
 
+Scopes can also be pinned per profile so every login for that profile requests
+them without repeating `--scopes`:
+
+```toml
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
+```
+
+The profile `scopes` value replaces the default delegated scope string (it is
+not additive); `offline_access` is appended when missing so refresh tokens
+keep working. Resolution order is `--scopes` or `TEAMS_CLI_SCOPES`, then the
+profile `scopes` field, then the default scope set. `teams auth consent-url`
+and `teams auth doctor` reflect the profile's resolved scopes, so admin
+consent links match what login will request. The default scope set remains
+free of admin-consent-required permissions; requesting broader scopes is an
+explicit opt-in for BYO app registrations. Do not use
+`https://graph.microsoft.com/.default` for delegated login — it would pull in
+every permission configured on the app registration instead of the explicit
+scope list.
+
 Customer-owned delegated app:
 
 ```bash
@@ -231,6 +254,7 @@ teams auth logout --all
 | `TEAMS_CLI_CLIENT_ID` | Entra app client ID. |
 | `TEAMS_CLI_CLIENT_SECRET` | Client secret for client credentials flow. |
 | `TEAMS_CLI_TENANT_ID` | Tenant ID or tenant domain. |
+| `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login. Same precedence as `--scopes`; ignored by client credentials login. |
 | `TEAMS_CLI_DISABLE_KEYRING` | Test-only escape hatch used by CLI tests to avoid real OS keyring access. |
 
 ## Microsoft references

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -93,6 +93,12 @@ These permissions cover the current chat read/write, channel-send, team/channel 
 teams auth login --device-code --scopes "User.Read ChannelMessage.Read.All offline_access"
 ```
 
+Downloading message file attachments (`teams message attachments download` on
+`reference` attachments stored in SharePoint/OneDrive) additionally requires
+the `Files.Read.All` delegated scope. Inline images and code snippets need no
+scopes beyond message reads. Add `Files.Read.All` to the profile's `scopes`
+and run `teams auth refresh` to pick it up without a new browser login.
+
 Future features may need additional consent.
 
 ## Login options

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -99,6 +99,15 @@ the `Files.Read.All` delegated scope. Inline images and code snippets need no
 scopes beyond message reads. Add `Files.Read.All` to the profile's `scopes`
 and run `teams auth refresh` to pick it up without a new browser login.
 
+Sending has the same split (see the scope table in docs/attachments-spec.md):
+`message send --image` sends the picture inside the message itself and needs
+no Files scope at all, while `message send --attach` must first upload the
+file to storage — your own OneDrive for chats (`Files.ReadWrite`), the team's
+SharePoint library for channels (`Files.ReadWrite.All`, typically admin
+consent). Note that Graph masks drives the token cannot see as 404 rather
+than 403, so a "not found" from `--attach` usually means the missing scope,
+not a missing file.
+
 Future features may need additional consent.
 
 ## Login options

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -26,8 +26,9 @@ teams [OPTIONS] <COMMAND>
 ```bash
 teams auth login [--device-code] [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth login --client-credentials --client-id ID --client-secret SECRET --tenant-id ID
+teams auth refresh [--scopes SCOPES]
 teams auth status
-teams auth consent-url [--client-id ID] [--tenant-id ID]
+teams auth consent-url [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth doctor [--client-id ID] [--tenant-id ID]
 teams auth list
 teams auth switch NAME
@@ -38,6 +39,8 @@ teams auth token [--format bearer|json]
 Delegated login defaults to the OSO public client app. Client credentials always require explicit customer credentials.
 
 Delegated scopes resolve as `--scopes` (or `TEAMS_CLI_SCOPES`), then the profile's `scopes` config field, then the built-in default scope set. `offline_access` is always ensured. `consent-url` and `doctor` reflect the resolved profile scopes.
+
+`auth refresh` silently redeems the stored refresh token for the resolved scopes — no browser — picking up newly admin-consented permissions. Without an explicit scope override it reuses the stored token's scope, never narrowing the session.
 
 ## Users
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -100,7 +100,9 @@ teams channel members remove TEAM_ID CHANNEL_ID MEMBER_ID
 ```bash
 teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (--body TEXT | --stdin) [--content-type text|html] [--adaptive-card PATH]
 teams message list (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID)
-teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
+teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) [--with-attachments]
+teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID)
+teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID (--body TEXT | --stdin) [--content-type text|html]
 teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
 teams message delete --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
@@ -111,6 +113,8 @@ teams message unpin --team TEAM_ID --channel CHANNEL_ID (PINNED_MESSAGE_ID | --p
 ```
 
 Normal message mutation requires delegated auth. App-only/client-credentials tokens are rejected for these commands.
+
+`message attachments` unifies the two ways Teams stores message media: inline images pasted into the compose box (Graph "hosted contents") and files attached via SharePoint/OneDrive (`reference` attachments). `list` returns an indexed inventory; `download` fetches everything downloadable by default, or one item with `--index` (add `--path FILE` for an exact destination, or `--path -` to stream to stdout). Inline images and code snippets need no scopes beyond message reads; file attachments additionally require the `Files.Read.All` delegated scope. `message get --with-attachments` embeds the same inventory under `attachment_items` in the message output.
 
 ## Chats
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -37,6 +37,8 @@ teams auth token [--format bearer|json]
 
 Delegated login defaults to the OSO public client app. Client credentials always require explicit customer credentials.
 
+Delegated scopes resolve as `--scopes` (or `TEAMS_CLI_SCOPES`), then the profile's `scopes` config field, then the built-in default scope set. `offline_access` is always ensured. `consent-url` and `doctor` reflect the resolved profile scopes.
+
 ## Users
 
 ```bash

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -48,7 +48,15 @@ Delegated scopes resolve as `--scopes` (or `TEAMS_CLI_SCOPES`), then the profile
 teams user me
 teams user get USER_ID_OR_UPN
 teams user list [--filter ODATA_FILTER]
+teams user resolve NAME_OR_EMAIL [--max-chats N]
 ```
+
+`user resolve` returns user candidates for a display name, email address, UPN,
+or object ID. It tries exact user lookup, People API search when `People.Read`
+is available (verified back to `/users/{userPrincipalName}` before returning
+an object ID), then a bounded shared-chat roster sweep. JSON candidates include
+`via` and the output includes a per-stage report so callers can tell which
+lookup paths were used. No candidates exits with code 5.
 
 ## Config
 
@@ -114,7 +122,7 @@ teams message unpin --team TEAM_ID --channel CHANNEL_ID (PINNED_MESSAGE_ID | --p
 
 Normal message mutation requires delegated auth. App-only/client-credentials tokens are rejected for these commands.
 
-`--image` sends a picture the way pasting a screenshot does — the bytes travel inside the message itself (a Graph "hosted content"), so it needs no scopes beyond sending messages. `--attach` uploads the file to real storage first (your OneDrive's `Microsoft Teams Chat Files` for chats, the team's SharePoint library for channels) and links it from the message; that upload needs `Files.ReadWrite` (chats) or `Files.ReadWrite.All` (channels). Both flags repeat for multiple files, and `--body` becomes optional when either is present. Inline images are capped at 3MB each; attachments at 4MB.
+`--image` sends a picture the way pasting a screenshot does — the bytes travel inside the message itself (a Graph "hosted content"), so it needs no scopes beyond sending messages. `--attach` uploads the file to real storage first (your OneDrive's `Microsoft Teams Chat Files` for chats, the team's SharePoint library for channels) and links it from the message; that upload needs `Files.ReadWrite` (chats) or `Files.ReadWrite.All` (channels). Both flags repeat for multiple files, and `--body` becomes optional when either is present. Inline images are capped at 3MB each; attachments use Graph's 250MB simple-upload limit.
 
 `message attachments` unifies the two ways Teams stores message media: inline images pasted into the compose box (Graph "hosted contents") and files attached via SharePoint/OneDrive (`reference` attachments). `list` returns an indexed inventory; `download` fetches everything downloadable by default, or one item with `--index` (add `--path FILE` for an exact destination, or `--path -` to stream to stdout). Inline images and code snippets need no scopes beyond message reads; file attachments additionally require the `Files.Read.All` delegated scope. `message get --with-attachments` embeds the same inventory under `attachment_items` in the message output.
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -98,12 +98,12 @@ teams channel members remove TEAM_ID CHANNEL_ID MEMBER_ID
 ## Messages
 
 ```bash
-teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (--body TEXT | --stdin) [--content-type text|html] [--adaptive-card PATH]
+teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) [--body TEXT | --stdin] [--content-type text|html] [--adaptive-card PATH] [--image PATH]... [--attach PATH]...
 teams message list (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID)
 teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) [--with-attachments]
 teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID)
 teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
-teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID (--body TEXT | --stdin) [--content-type text|html]
+teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID [--body TEXT | --stdin] [--content-type text|html] [--image PATH]... [--attach PATH]...
 teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
 teams message delete --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
 teams message react --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID (REACTION | --reaction REACTION)
@@ -113,6 +113,8 @@ teams message unpin --team TEAM_ID --channel CHANNEL_ID (PINNED_MESSAGE_ID | --p
 ```
 
 Normal message mutation requires delegated auth. App-only/client-credentials tokens are rejected for these commands.
+
+`--image` sends a picture the way pasting a screenshot does — the bytes travel inside the message itself (a Graph "hosted content"), so it needs no scopes beyond sending messages. `--attach` uploads the file to real storage first (your OneDrive's `Microsoft Teams Chat Files` for chats, the team's SharePoint library for channels) and links it from the message; that upload needs `Files.ReadWrite` (chats) or `Files.ReadWrite.All` (channels). Both flags repeat for multiple files, and `--body` becomes optional when either is present. Inline images are capped at 3MB each; attachments at 4MB.
 
 `message attachments` unifies the two ways Teams stores message media: inline images pasted into the compose box (Graph "hosted contents") and files attached via SharePoint/OneDrive (`reference` attachments). `list` returns an indexed inventory; `download` fetches everything downloadable by default, or one item with `--index` (add `--path FILE` for an exact destination, or `--path -` to stream to stdout). Inline images and code snippets need no scopes beyond message reads; file attachments additionally require the `Files.Read.All` delegated scope. `message get --with-attachments` embeds the same inventory under `attachment_items` in the message output.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -171,6 +171,24 @@ item to stdout. File attachments (SharePoint/OneDrive references) need the
 `Files.Read.All` delegated scope; inline images work with plain message-read
 scopes.
 
+## Send a screenshot or attach a file
+
+`--image` reproduces the paste-a-screenshot experience — the picture travels inside
+the message and needs no extra permissions. `--attach` uploads to OneDrive/SharePoint
+first and needs a `Files.ReadWrite` scope (see docs/attachments-spec.md):
+
+```bash
+teams message send \
+  --chat "$CHAT_ID" \
+  --body "here's the error I'm seeing" \
+  --image ./screenshot.png --output json
+
+teams message send \
+  --team "$TEAM_ID" \
+  --channel "$CHANNEL_ID" \
+  --attach ./NetskopeLogs.zip --output json
+```
+
 ## Agency client update
 
 ```bash

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -145,6 +145,32 @@ teams file download \
   --path ./teams-cli-smoke.txt
 ```
 
+## Read a screenshot pasted into a message
+
+Users paste screenshots directly into Teams messages; those are stored as
+Graph "hosted contents", not file attachments. Enumerate and download
+everything readable in a message:
+
+```bash
+teams message attachments list \
+  --team "$TEAM_ID" \
+  --channel "$CHANNEL_ID" \
+  "$MESSAGE_ID" --output json
+
+teams message attachments download \
+  --team "$TEAM_ID" \
+  --channel "$CHANNEL_ID" \
+  "$MESSAGE_ID" --dir ./attachments --output json
+```
+
+The download result lists one entry per item with its local path, size, and
+MIME type — ready for a multimodal agent to read. Use `--chat "$CHAT_ID"`
+instead of `--team`/`--channel` for chat messages, `--reply "$REPLY_ID"` for
+a reply inside a channel thread, and `--index N --path -` to stream a single
+item to stdout. File attachments (SharePoint/OneDrive references) need the
+`Files.Read.All` delegated scope; inline images work with plain message-read
+scopes.
+
 ## Agency client update
 
 ```bash

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -52,7 +52,15 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 .fi
+.PP
+The optional
+.B scopes
+field replaces the default delegated scope string for that profile;
+.B offline_access
+is appended when missing. Use it when a BYO app has admin-consented
+permissions beyond the defaults.
 .PP
 Then run:
 .PP
@@ -117,6 +125,11 @@ Client secret for client credentials flow.
 .TP
 .B TEAMS_CLI_TENANT_ID
 Tenant ID or tenant domain.
+.TP
+.B TEAMS_CLI_SCOPES
+Delegated OAuth scopes for login. Same precedence as
+.B --scopes.
+Ignored by client credentials login.
 .TP
 .B TEAMS_CLI_DISABLE_KEYRING
 Test-only switch used to avoid OS keyring access in automated tests. Do not use

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -102,6 +102,27 @@ For unattended service-identity posting, the intended future direction is a
 Teams app/bot proactive messaging mode. In that model a customer installs a
 Teams app or bot, and messages are sent as that app identity instead of a
 delegated human user.
+.SH SCOPE UPGRADES
+Refresh tokens are bound to the user and client, not to the scopes originally
+requested, so an existing session can pick up newly consented delegated
+permissions without interactive re-auth:
+.PP
+.nf
+teams auth consent-url --scopes "User.Read People.Read offline_access"
+teams auth refresh
+.fi
+.PP
+.B auth refresh
+redeems the stored refresh token for the resolved scopes (\fB--scopes\fR or
+.B TEAMS_CLI_SCOPES,
+then the profile
+.B scopes
+field). Without an explicit override it reuses the stored token's scope, so a
+plain refresh never narrows a session. If a requested scope has not been
+consented, the identity platform rejects the request (AADSTS65001) instead of
+issuing a narrower token; grant consent and retry, or run
+.B teams auth login
+for interactive consent.
 .SH TOKEN STORAGE
 Tokens are stored in the operating system credential store:
 .PP
@@ -136,8 +157,10 @@ Test-only switch used to avoid OS keyring access in automated tests. Do not use
 for real login sessions.
 .SH KNOWN GAPS
 Stored access tokens are refreshed automatically when a refresh token is
-available. If the refresh token is missing, expired, revoked, or rejected by
-the identity platform, run:
+available. Use
+.B teams auth refresh
+to force a refresh explicitly. If the refresh token is missing, expired,
+revoked, or rejected by the identity platform, run:
 .PP
 .nf
 teams auth login --device-code

--- a/docs/man/teams-config.5
+++ b/docs/man/teams-config.5
@@ -46,6 +46,7 @@ auth_app = "byo"
 client_id = "11111111-1111-1111-1111-111111111111"
 tenant_id = "22222222-2222-2222-2222-222222222222"
 auth_flow = "device-code"
+scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 .fi
 .SH DEFAULT SECTION
 .TP
@@ -129,6 +130,12 @@ used by docs and examples include
 .B device-code,
 and
 .B auth-code-pkce.
+.TP
+.B scopes
+Delegated OAuth scope string requested at login for this profile. Replaces the
+built-in default delegated scopes;
+.B offline_access
+is appended when missing. Ignored by client credentials login.
 .SH RESOLUTION ORDER
 Client ID and tenant ID resolution:
 .nf
@@ -141,6 +148,13 @@ Client secret resolution:
 .nf
 1. CLI flag
 2. TEAMS_CLI_CLIENT_SECRET
+.fi
+.PP
+Delegated scope resolution:
+.nf
+1. --scopes flag or TEAMS_CLI_SCOPES
+2. Selected config profile scopes
+3. Built-in default delegated scopes
 .fi
 .PP
 Access token resolution for normal commands:

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -134,12 +134,12 @@ teams channel members remove TEAM_ID CHANNEL_ID MEMBER_ID
 .fi
 .SH MESSAGE COMMANDS
 .nf
-teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (--body TEXT | --stdin) [--content-type text|html] [--adaptive-card PATH]
+teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) [--body TEXT | --stdin] [--content-type text|html] [--adaptive-card PATH] [--image PATH]... [--attach PATH]...
 teams message list (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID)
 teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) [--with-attachments]
 teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID)
 teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
-teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID (--body TEXT | --stdin) [--content-type text|html]
+teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID [--body TEXT | --stdin] [--content-type text|html] [--image PATH]... [--attach PATH]...
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message MESSAGE_ID --body TEXT
 teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
 teams message delete --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -72,6 +72,13 @@ Credential resolution for explicit client ID and tenant ID is CLI flag,
 environment variable, then config profile. Client secret resolution is CLI
 flag, then
 .B TEAMS_CLI_CLIENT_SECRET.
+Delegated scope resolution is
+.B --scopes
+or
+.B TEAMS_CLI_SCOPES,
+then the profile
+.B scopes
+field, then the built-in default delegated scopes.
 Normal command token resolution is
 .B TEAMS_CLI_ACCESS_TOKEN
 then the OS keyring token for the selected profile.
@@ -263,6 +270,11 @@ Azure AD client secret for client credentials auth.
 .TP
 .B TEAMS_CLI_TENANT_ID
 Azure AD tenant ID.
+.TP
+.B TEAMS_CLI_SCOPES
+Delegated OAuth scopes for login. Same precedence as
+.B --scopes.
+Ignored by client credentials login.
 .TP
 .B RUST_LOG
 Tracing filter, for example

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -92,7 +92,19 @@ then the OS keyring token for the selected profile.
 teams user me
 teams user get USER_ID_OR_UPN
 teams user list [--filter ODATA_FILTER]
+teams user resolve NAME_OR_EMAIL [--max-chats N]
 .fi
+.PP
+.B user resolve
+returns user candidates for a display name, email address, UPN, or object ID.
+It tries exact user lookup, People API search when
+.B People.Read
+is available (verified back to
+.B /users/{userPrincipalName}
+before returning an object ID), then a bounded shared-chat roster sweep. JSON candidates include
+.B via
+and a per-stage report so callers can see which lookup paths were used. No
+candidates exits with code 5.
 .SH CONFIG COMMANDS
 .nf
 teams config init

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -136,7 +136,9 @@ teams channel members remove TEAM_ID CHANNEL_ID MEMBER_ID
 .nf
 teams message send (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (--body TEXT | --stdin) [--content-type text|html] [--adaptive-card PATH]
 teams message list (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID)
-teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
+teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) [--with-attachments]
+teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID)
+teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID (--body TEXT | --stdin) [--content-type text|html]
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message MESSAGE_ID --body TEXT
 teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -51,8 +51,9 @@ Follow Graph pagination and return all pages.
 .SH AUTHENTICATION
 .nf
 teams auth login [--client-credentials] [--device-code] [--client-id ID] [--client-secret SECRET] [--tenant-id ID] [--scopes SCOPES]
+teams auth refresh [--scopes SCOPES]
 teams auth status
-teams auth consent-url [--client-id ID] [--tenant-id ID]
+teams auth consent-url [--client-id ID] [--tenant-id ID] [--scopes SCOPES]
 teams auth doctor [--client-id ID] [--tenant-id ID]
 teams auth list
 teams auth switch NAME
@@ -79,6 +80,10 @@ or
 then the profile
 .B scopes
 field, then the built-in default delegated scopes.
+.B teams auth refresh
+silently redeems the stored refresh token for the resolved scopes, picking up
+newly admin-consented permissions without a browser; without an explicit
+override it reuses the stored token's scope.
 Normal command token resolution is
 .B TEAMS_CLI_ACCESS_TOKEN
 then the OS keyring token for the selected profile.

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -257,6 +257,15 @@ impl GraphClient {
 
     /// GET raw bytes (for file download).
     pub async fn get_bytes(&self, url: &str) -> Result<Vec<u8>> {
+        self.get_bytes_with_content_type(url).await.map(|(b, _)| b)
+    }
+
+    /// GET raw bytes along with the response's Content-Type header. Hosted
+    /// contents (`/$value`) only expose their MIME type via that header.
+    pub async fn get_bytes_with_content_type(
+        &self,
+        url: &str,
+    ) -> Result<(Vec<u8>, Option<String>)> {
         let max_retries = self.network.max_retries;
         let backoff_base = self.network.retry_backoff_base;
 
@@ -299,8 +308,13 @@ impl GraphClient {
                 return Err(self.error_for_status(status, body));
             }
 
+            let content_type = resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|v| v.split(';').next().unwrap_or(v).trim().to_string());
             let bytes = resp.bytes().await.map_err(TeamsError::NetworkError)?;
-            return Ok(bytes.to_vec());
+            return Ok((bytes.to_vec(), content_type));
         }
 
         Err(TeamsError::ApiError {

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -266,7 +266,31 @@ pub fn drive_item_content(drive_id: &str, item_id: &str) -> String {
 }
 
 pub fn drive_upload_to_folder(drive_id: &str, parent_id: &str, filename: &str) -> String {
-    format!("{GRAPH_V1}/drives/{drive_id}/items/{parent_id}:/{filename}:/content")
+    let name = urlencoding::encode(filename);
+    format!("{GRAPH_V1}/drives/{drive_id}/items/{parent_id}:/{name}:/content")
+}
+
+/// Upload into a drive folder, renaming on filename collision instead of
+/// replacing — used for message attachments, where clobbering a previously
+/// shared file would silently rewrite history.
+pub fn drive_upload_to_folder_rename(drive_id: &str, parent_id: &str, filename: &str) -> String {
+    let name = urlencoding::encode(filename);
+    format!(
+        "{GRAPH_V1}/drives/{drive_id}/items/{parent_id}:/{name}:/content?@microsoft.graph.conflictBehavior=rename"
+    )
+}
+
+pub fn me_drive_root_children() -> String {
+    format!("{GRAPH_V1}/me/drive/root/children")
+}
+
+/// Upload into the signed-in user's OneDrive `Microsoft Teams Chat Files`
+/// folder, where the Teams client itself puts files attached to chats.
+pub fn me_chat_files_upload(filename: &str) -> String {
+    let name = urlencoding::encode(filename);
+    format!(
+        "{GRAPH_V1}/me/drive/root:/Microsoft%20Teams%20Chat%20Files/{name}:/content?@microsoft.graph.conflictBehavior=rename"
+    )
 }
 
 pub fn drive_item_create_link(drive_id: &str, item_id: &str) -> String {
@@ -385,6 +409,30 @@ mod tests {
         assert!(url.ends_with("/hostedContents/aWQ9%2Bx%2Fz%3D%3D/$value"));
         assert!(
             url.starts_with("https://graph.microsoft.com/v1.0/teams/t1/channels/c1/messages/m1/")
+        );
+    }
+
+    #[test]
+    fn chat_files_upload_encodes_filename_and_renames_on_conflict() {
+        let url = me_chat_files_upload("Net skope Logs.zip");
+        assert_eq!(
+            url,
+            "https://graph.microsoft.com/v1.0/me/drive/root:/Microsoft%20Teams%20Chat%20Files/Net%20skope%20Logs.zip:/content?@microsoft.graph.conflictBehavior=rename"
+        );
+    }
+
+    #[test]
+    fn drive_uploads_encode_filename_path_segment() {
+        // '#' and '?' would otherwise be parsed as fragment/query, silently
+        // truncating the DriveItem path.
+        let url = drive_upload_to_folder_rename("d1", "p1", "report #3?.xlsx");
+        assert_eq!(
+            url,
+            "https://graph.microsoft.com/v1.0/drives/d1/items/p1:/report%20%233%3F.xlsx:/content?@microsoft.graph.conflictBehavior=rename"
+        );
+        assert_eq!(
+            drive_upload_to_folder("d1", "p1", "a b.txt"),
+            "https://graph.microsoft.com/v1.0/drives/d1/items/p1:/a%20b.txt:/content"
         );
     }
 

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -272,3 +272,129 @@ pub fn drive_upload_to_folder(drive_id: &str, parent_id: &str, filename: &str) -
 pub fn drive_item_create_link(drive_id: &str, item_id: &str) -> String {
     format!("{GRAPH_V1}/drives/{drive_id}/items/{item_id}/createLink")
 }
+
+// --- Hosted contents (inline images, code snippets) ---
+
+pub fn channel_message_hosted_contents(
+    team_id: &str,
+    channel_id: &str,
+    message_id: &str,
+) -> String {
+    format!("{GRAPH_V1}/teams/{team_id}/channels/{channel_id}/messages/{message_id}/hostedContents")
+}
+
+pub fn channel_message_hosted_content_value(
+    team_id: &str,
+    channel_id: &str,
+    message_id: &str,
+    hosted_content_id: &str,
+) -> String {
+    let id = urlencoding::encode(hosted_content_id);
+    format!(
+        "{GRAPH_V1}/teams/{team_id}/channels/{channel_id}/messages/{message_id}/hostedContents/{id}/$value"
+    )
+}
+
+pub fn channel_reply_hosted_contents(
+    team_id: &str,
+    channel_id: &str,
+    message_id: &str,
+    reply_id: &str,
+) -> String {
+    format!(
+        "{GRAPH_V1}/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies/{reply_id}/hostedContents"
+    )
+}
+
+pub fn channel_reply_hosted_content_value(
+    team_id: &str,
+    channel_id: &str,
+    message_id: &str,
+    reply_id: &str,
+    hosted_content_id: &str,
+) -> String {
+    let id = urlencoding::encode(hosted_content_id);
+    format!(
+        "{GRAPH_V1}/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies/{reply_id}/hostedContents/{id}/$value"
+    )
+}
+
+pub fn channel_message_reply(
+    team_id: &str,
+    channel_id: &str,
+    message_id: &str,
+    reply_id: &str,
+) -> String {
+    format!(
+        "{GRAPH_V1}/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies/{reply_id}"
+    )
+}
+
+pub fn chat_message_hosted_contents(chat_id: &str, message_id: &str) -> String {
+    format!("{GRAPH_V1}/chats/{chat_id}/messages/{message_id}/hostedContents")
+}
+
+pub fn chat_message_hosted_content_value(
+    chat_id: &str,
+    message_id: &str,
+    hosted_content_id: &str,
+) -> String {
+    let id = urlencoding::encode(hosted_content_id);
+    format!("{GRAPH_V1}/chats/{chat_id}/messages/{message_id}/hostedContents/{id}/$value")
+}
+
+// --- Shares (resolving attachment contentUrl to a drive item) ---
+
+/// Encode a SharePoint/OneDrive web URL as a Graph sharing token: `u!` plus
+/// unpadded base64url of the URL, per the Graph shares API convention.
+pub fn sharing_url_token(url: &str) -> String {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine as _;
+    format!("u!{}", URL_SAFE_NO_PAD.encode(url))
+}
+
+pub fn shares_drive_item_content(sharing_token: &str) -> String {
+    format!("{GRAPH_V1}/shares/{sharing_token}/driveItem/content")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sharing_url_token_matches_graph_convention() {
+        // Expected value computed with: printf '%s' "$URL" | base64 | tr '+/' '-_' | tr -d '='
+        let url = "https://tenant-my.sharepoint.com/personal/user/Documents/Microsoft%20Teams%20Chat%20Files/NetskopeLogs.zip";
+        let token = sharing_url_token(url);
+        assert!(token.starts_with("u!"));
+        assert!(!token.contains('='), "token must be unpadded");
+        assert!(
+            !token.contains('+') && !token.contains('/'),
+            "token must be base64url"
+        );
+        assert_eq!(
+            token,
+            "u!aHR0cHM6Ly90ZW5hbnQtbXkuc2hhcmVwb2ludC5jb20vcGVyc29uYWwvdXNlci9Eb2N1bWVudHMvTWljcm9zb2Z0JTIwVGVhbXMlMjBDaGF0JTIwRmlsZXMvTmV0c2tvcGVMb2dzLnppcA"
+        );
+    }
+
+    #[test]
+    fn hosted_content_value_encodes_id() {
+        // Base64 IDs can contain '+', '/', and '=' which must be percent-encoded in a path.
+        let url = channel_message_hosted_content_value("t1", "c1", "m1", "aWQ9+x/z==");
+        assert!(url.ends_with("/hostedContents/aWQ9%2Bx%2Fz%3D%3D/$value"));
+        assert!(
+            url.starts_with("https://graph.microsoft.com/v1.0/teams/t1/channels/c1/messages/m1/")
+        );
+    }
+
+    #[test]
+    fn chat_hosted_contents_urls() {
+        assert_eq!(
+            chat_message_hosted_contents("19:abc", "m1"),
+            "https://graph.microsoft.com/v1.0/chats/19:abc/messages/m1/hostedContents"
+        );
+        assert!(chat_message_hosted_content_value("19:abc", "m1", "hc1")
+            .ends_with("/chats/19:abc/messages/m1/hostedContents/hc1/$value"));
+    }
+}

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -7,11 +7,19 @@ pub fn me() -> String {
 }
 
 pub fn user(id: &str) -> String {
-    format!("{GRAPH_V1}/users/{id}")
+    user_at(GRAPH_V1, id)
+}
+
+pub fn user_at(base: &str, id: &str) -> String {
+    format!("{base}/users/{id}")
 }
 
 pub fn users() -> String {
     format!("{GRAPH_V1}/users")
+}
+
+pub fn my_people_at(base: &str) -> String {
+    format!("{base}/me/people")
 }
 
 // --- Teams ---
@@ -108,7 +116,11 @@ pub fn channel_pinned_message(team_id: &str, channel_id: &str, pinned_message_id
 
 // --- Chats ---
 pub fn my_chats() -> String {
-    format!("{GRAPH_V1}/me/chats")
+    my_chats_at(GRAPH_V1)
+}
+
+pub fn my_chats_at(base: &str) -> String {
+    format!("{base}/me/chats")
 }
 
 /// Chat creation lives at `/chats`; `/me/chats` is list-only and returns
@@ -122,7 +134,11 @@ pub fn chat(id: &str) -> String {
 }
 
 pub fn chat_members(chat_id: &str) -> String {
-    format!("{GRAPH_V1}/chats/{chat_id}/members")
+    chat_members_at(GRAPH_V1, chat_id)
+}
+
+pub fn chat_members_at(base: &str, chat_id: &str) -> String {
+    format!("{base}/chats/{chat_id}/members")
 }
 
 pub fn chat_member(chat_id: &str, member_id: &str) -> String {

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -148,6 +148,150 @@ pub async fn upload_file(
         .await
 }
 
+/// Upload a message attachment into the signed-in user's OneDrive
+/// `Microsoft Teams Chat Files` folder (where the Teams client puts files
+/// attached to chats), renaming on collision.
+pub async fn upload_chat_attachment(
+    client: &GraphClient,
+    filename: &str,
+    bytes: Vec<u8>,
+    content_type: &str,
+) -> Result<DriveItem> {
+    check_upload_size(&bytes)?;
+    let url = endpoints::me_chat_files_upload(filename);
+    match client.put_bytes(&url, bytes.clone(), content_type).await {
+        // A 404 can mean the `Microsoft Teams Chat Files` folder simply
+        // doesn't exist yet (the user never attached a chat file); create it
+        // and retry once. If the drive itself is inaccessible the create
+        // fails too and the hint below explains the scope angle.
+        Err(TeamsError::NotFound(_)) => {
+            ensure_chat_files_folder(client)
+                .await
+                .map_err(|e| attach_scope_hint(e, AttachTarget::Chat))?;
+            client
+                .put_bytes(&url, bytes, content_type)
+                .await
+                .map_err(|e| attach_scope_hint(e, AttachTarget::Chat))
+        }
+        other => other.map_err(|e| attach_scope_hint(e, AttachTarget::Chat)),
+    }
+}
+
+async fn ensure_chat_files_folder(client: &GraphClient) -> Result<()> {
+    let body = serde_json::json!({
+        "name": "Microsoft Teams Chat Files",
+        "folder": {},
+        "@microsoft.graph.conflictBehavior": "fail",
+    });
+    match client
+        .post::<DriveItem, _>(&endpoints::me_drive_root_children(), &body)
+        .await
+    {
+        Ok(_) => Ok(()),
+        // 409 nameAlreadyExists means the folder is there; anything else is real.
+        Err(TeamsError::ApiError { status: 409, .. }) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Upload a message attachment into the channel's folder in the team's
+/// SharePoint library, renaming on collision (unlike `upload_file`, which
+/// replaces — attachments must never rewrite a previously shared file).
+pub async fn upload_channel_attachment(
+    client: &GraphClient,
+    team_id: &str,
+    channel_id: &str,
+    filename: &str,
+    bytes: Vec<u8>,
+    content_type: &str,
+) -> Result<DriveItem> {
+    check_upload_size(&bytes)?;
+    let folder = get_files_folder(client, team_id, channel_id)
+        .await
+        .map_err(|e| attach_scope_hint(e, AttachTarget::Channel))?;
+    let drive_id = folder
+        .parent_reference
+        .as_ref()
+        .and_then(|r| r.drive_id.as_deref())
+        .ok_or_else(|| TeamsError::ApiError {
+            status: 500,
+            message: "filesFolder missing driveId".to_string(),
+        })?;
+    let folder_id = folder.id.as_deref().ok_or_else(|| TeamsError::ApiError {
+        status: 500,
+        message: "filesFolder missing id".to_string(),
+    })?;
+
+    client
+        .put_bytes(
+            &endpoints::drive_upload_to_folder_rename(drive_id, folder_id, filename),
+            bytes,
+            content_type,
+        )
+        .await
+        .map_err(|e| attach_scope_hint(e, AttachTarget::Channel))
+}
+
+enum AttachTarget {
+    Chat,
+    Channel,
+}
+
+/// Turn a bare 403/404 from the attachment-upload step into an abbreviated
+/// version of the scope explainer in docs/attachments-spec.md: say where the
+/// file was headed, which scope that storage write needs, and how to grant it.
+///
+/// Graph masks drives the token cannot see as 404 `itemNotFound` rather than
+/// 403 (verified live: `GET /me/drive` without any Files scope is a 404), so
+/// both statuses get the teaching treatment.
+fn attach_scope_hint(err: TeamsError, target: AttachTarget) -> TeamsError {
+    let (storage, scope) = match target {
+        AttachTarget::Chat => (
+            "your own OneDrive ('Microsoft Teams Chat Files')",
+            "Files.ReadWrite",
+        ),
+        AttachTarget::Channel => (
+            "the team's SharePoint library (the channel's Files tab)",
+            "Files.ReadWrite.All (admin consent may be required)",
+        ),
+    };
+    let how = "Add the scope to your profile's `scopes` and run `teams auth refresh`. \
+               See docs/auth.md and docs/attachments-spec.md for the full explanation.";
+    match err {
+        TeamsError::PermissionDenied(msg) => TeamsError::PermissionDenied(format!(
+            "{msg}\nHint: attaching a file uploads it to {storage} before linking it in \
+             the message; that storage write needs the {scope} delegated scope, which \
+             your token doesn't have. Inline images (--image) travel inside the message \
+             and don't need it. {how}"
+        )),
+        TeamsError::NotFound(msg) => TeamsError::NotFound(format!(
+            "{msg}\nHint: attaching a file uploads it to {storage} before linking it in \
+             the message, and Graph reported that storage as not found. That usually \
+             means the token lacks the {scope} delegated scope (Graph masks drives the \
+             token cannot see as 404, not 403){}. Inline images (--image) travel inside \
+             the message and need no Files scope. {how}",
+            match target {
+                AttachTarget::Chat =>
+                    ", or your OneDrive has never been provisioned — \
+                                       open onedrive.com once to initialize it",
+                AttachTarget::Channel => "",
+            }
+        )),
+        other => other,
+    }
+}
+
+fn check_upload_size(bytes: &[u8]) -> Result<()> {
+    if bytes.len() > MAX_UPLOAD_SIZE {
+        return Err(TeamsError::InvalidInput(format!(
+            "File size ({} bytes) exceeds the 4MB simple-upload limit for message \
+             attachments.",
+            bytes.len()
+        )));
+    }
+    Ok(())
+}
+
 pub async fn delete_file(
     client: &GraphClient,
     team_id: &str,

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -87,6 +87,29 @@ pub async fn download_file(
         .await
 }
 
+/// Download the bytes behind a shared web URL, following Graph's redirect to
+/// the pre-authenticated download URL.
+pub async fn download_shared_item(
+    client: &GraphClient,
+    content_url: &str,
+) -> Result<(Vec<u8>, Option<String>)> {
+    let token = endpoints::sharing_url_token(content_url);
+    client
+        .get_bytes_with_content_type(&endpoints::shares_drive_item_content(&token))
+        .await
+        .map_err(shares_scope_hint)
+}
+
+fn shares_scope_hint(err: TeamsError) -> TeamsError {
+    match err {
+        TeamsError::PermissionDenied(msg) => TeamsError::PermissionDenied(format!(
+            "{msg}\nHint: downloading file attachments requires the Files.Read.All delegated \
+             scope. Add it to your profile's scopes and run `teams auth refresh`."
+        )),
+        other => other,
+    }
+}
+
 pub async fn upload_file(
     client: &GraphClient,
     team_id: &str,

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -4,7 +4,7 @@ use crate::models::file::{DriveItem, FilesFolder, ShareLinkRequest, ShareLinkRes
 use super::client::{GraphClient, PaginationOpts};
 use super::endpoints;
 
-const MAX_UPLOAD_SIZE: usize = 4 * 1024 * 1024; // 4MB
+const MAX_UPLOAD_SIZE: usize = 250 * 1024 * 1024; // DriveItem simple upload limit.
 
 pub async fn get_files_folder(
     client: &GraphClient,
@@ -120,7 +120,7 @@ pub async fn upload_file(
 ) -> Result<DriveItem> {
     if bytes.len() > MAX_UPLOAD_SIZE {
         return Err(TeamsError::InvalidInput(format!(
-            "File size ({} bytes) exceeds 4MB upload limit. Use upload sessions for larger files.",
+            "File size ({} bytes) exceeds the 250MB simple upload limit. Use upload sessions for larger files.",
             bytes.len()
         )));
     }
@@ -284,7 +284,7 @@ fn attach_scope_hint(err: TeamsError, target: AttachTarget) -> TeamsError {
 fn check_upload_size(bytes: &[u8]) -> Result<()> {
     if bytes.len() > MAX_UPLOAD_SIZE {
         return Err(TeamsError::InvalidInput(format!(
-            "File size ({} bytes) exceeds the 4MB simple-upload limit for message \
+            "File size ({} bytes) exceeds the 250MB simple-upload limit for message \
              attachments.",
             bytes.len()
         )));

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -1,10 +1,134 @@
 use crate::error::Result;
 use crate::models::message::{
-    ChatMessage, PinMessageRequest, PinnedMessage, ReactionRequest, SendMessageRequest,
+    ChatMessage, ChatMessageHostedContent, PinMessageRequest, PinnedMessage, ReactionRequest,
+    SendMessageRequest,
 };
 
 use super::client::{GraphClient, PaginationOpts};
 use super::endpoints;
+
+/// Location of a message for operations that work across channel messages,
+/// channel thread replies, and chat messages.
+#[derive(Debug, Clone)]
+pub enum MessageRef {
+    Channel {
+        team_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    ChannelReply {
+        team_id: String,
+        channel_id: String,
+        message_id: String,
+        reply_id: String,
+    },
+    Chat {
+        chat_id: String,
+        message_id: String,
+    },
+}
+
+impl MessageRef {
+    fn message_url(&self) -> String {
+        match self {
+            Self::Channel {
+                team_id,
+                channel_id,
+                message_id,
+            } => endpoints::channel_message(team_id, channel_id, message_id),
+            Self::ChannelReply {
+                team_id,
+                channel_id,
+                message_id,
+                reply_id,
+            } => endpoints::channel_message_reply(team_id, channel_id, message_id, reply_id),
+            Self::Chat {
+                chat_id,
+                message_id,
+            } => endpoints::chat_message(chat_id, message_id),
+        }
+    }
+
+    fn hosted_contents_url(&self) -> String {
+        match self {
+            Self::Channel {
+                team_id,
+                channel_id,
+                message_id,
+            } => endpoints::channel_message_hosted_contents(team_id, channel_id, message_id),
+            Self::ChannelReply {
+                team_id,
+                channel_id,
+                message_id,
+                reply_id,
+            } => {
+                endpoints::channel_reply_hosted_contents(team_id, channel_id, message_id, reply_id)
+            }
+            Self::Chat {
+                chat_id,
+                message_id,
+            } => endpoints::chat_message_hosted_contents(chat_id, message_id),
+        }
+    }
+
+    fn hosted_content_value_url(&self, hosted_content_id: &str) -> String {
+        match self {
+            Self::Channel {
+                team_id,
+                channel_id,
+                message_id,
+            } => endpoints::channel_message_hosted_content_value(
+                team_id,
+                channel_id,
+                message_id,
+                hosted_content_id,
+            ),
+            Self::ChannelReply {
+                team_id,
+                channel_id,
+                message_id,
+                reply_id,
+            } => endpoints::channel_reply_hosted_content_value(
+                team_id,
+                channel_id,
+                message_id,
+                reply_id,
+                hosted_content_id,
+            ),
+            Self::Chat {
+                chat_id,
+                message_id,
+            } => {
+                endpoints::chat_message_hosted_content_value(chat_id, message_id, hosted_content_id)
+            }
+        }
+    }
+}
+
+pub async fn get_message(client: &GraphClient, message: &MessageRef) -> Result<ChatMessage> {
+    client.get(&message.message_url(), &[]).await
+}
+
+pub async fn list_hosted_contents(
+    client: &GraphClient,
+    message: &MessageRef,
+) -> Result<Vec<ChatMessageHostedContent>> {
+    client
+        .get_all_pages(&message.hosted_contents_url(), &[])
+        .await
+}
+
+/// Fetch a hosted content's raw bytes; the MIME type is only available from
+/// the response's Content-Type header, returned alongside the bytes.
+pub async fn get_hosted_content_bytes(
+    client: &GraphClient,
+    message: &MessageRef,
+    hosted_content_id: &str,
+) -> Result<(Vec<u8>, Option<String>)> {
+    client
+        .get_bytes_with_content_type(&message.hosted_content_value_url(hosted_content_id))
+        .await
+}
 
 // --- Channel Messages ---
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod meetings;
 pub mod messages;
 pub mod notifications;
 pub mod presence;
+pub mod resolve;
 pub mod search;
 pub mod subscriptions;
 pub mod tags;

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -1,0 +1,755 @@
+use std::collections::HashSet;
+
+use serde::Serialize;
+
+use crate::error::{Result, TeamsError};
+use crate::models::chat::Chat;
+use crate::models::common::PageResponse;
+use crate::models::member::ConversationMember;
+use crate::models::user::{Person, User};
+
+use super::client::GraphClient;
+use super::endpoints;
+
+/// A person the resolver considers a plausible match for the query. The
+/// `via` field records which lookup path produced the candidate so callers
+/// can judge how much to trust it: `upn` is authoritative, `people-search`
+/// is relevance-ranked, `roster` is a name/email match from shared chats.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveCandidate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_principal_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub department: Option<String>,
+    pub via: String,
+}
+
+/// How strong a roster match is. A full-address email match identifies one
+/// mailbox and ends the sweep early; alias and display-name matches can
+/// collide with other people, so the sweep keeps scanning for the rest.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum MatchConfidence {
+    Email,
+    Name,
+}
+
+/// What happened at each resolution stage: `hit`, `miss`, `forbidden`
+/// (token lacks the scope), or `skipped` (not attempted). For the roster
+/// stage, `skipped_chats` counts rosters that could not be read (403/404),
+/// marking the result as potentially incomplete.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageReport {
+    pub stage: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_chats: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveResult {
+    pub query: String,
+    pub candidates: Vec<ResolveCandidate>,
+    pub stages: Vec<StageReport>,
+}
+
+/// Resolve a colleague reference (display name, email, UPN, or object ID)
+/// to user candidates, degrading gracefully with the token's scopes:
+///
+/// 1. Exact `/users/{q}` lookup when the query looks like a UPN or GUID
+///    (baseline User.ReadBasic.All).
+/// 2. People search via `/me/people` (People.Read).
+/// 3. Roster sweep over group/meeting chat members (baseline chat scopes),
+///    bounded by `max_chats`; an exact email match stops it early, while
+///    bare-name matches keep it scanning for namesakes.
+///
+/// A stage that fails with 403 is recorded as `forbidden` and the resolver
+/// moves on; any other transport or server error aborts the resolution.
+pub async fn resolve_user(
+    client: &GraphClient,
+    query: &str,
+    max_chats: u64,
+) -> Result<ResolveResult> {
+    resolve_user_at(client, endpoints::GRAPH_V1, query, max_chats).await
+}
+
+pub(crate) async fn resolve_user_at(
+    client: &GraphClient,
+    base: &str,
+    query: &str,
+    max_chats: u64,
+) -> Result<ResolveResult> {
+    let mut stages: Vec<StageReport> = Vec::new();
+
+    if looks_like_exact_reference(query) {
+        match client
+            .get::<User>(&format!("{base}/users/{query}"), &[])
+            .await
+        {
+            Ok(user) => {
+                stages.push(stage("upn", "hit"));
+                stages.push(stage("people-search", "skipped"));
+                stages.push(stage("roster", "skipped"));
+                return Ok(ResolveResult {
+                    query: query.to_string(),
+                    candidates: vec![candidate_from_user(&user)],
+                    stages,
+                });
+            }
+            Err(e) if is_forbidden(&e) => stages.push(stage("upn", "forbidden")),
+            Err(TeamsError::NotFound(_)) | Err(TeamsError::ApiError { status: 400, .. }) => {
+                stages.push(stage("upn", "miss"));
+            }
+            Err(e) => return Err(e),
+        }
+    } else {
+        stages.push(stage("upn", "skipped"));
+    }
+
+    match search_people(client, base, query).await {
+        Ok(people) if !people.is_empty() => {
+            stages.push(stage("people-search", "hit"));
+            stages.push(stage("roster", "skipped"));
+            return Ok(ResolveResult {
+                query: query.to_string(),
+                candidates: people.iter().map(candidate_from_person).collect(),
+                stages,
+            });
+        }
+        Ok(_) => stages.push(stage("people-search", "miss")),
+        Err(e) if is_forbidden(&e) => stages.push(stage("people-search", "forbidden")),
+        Err(e) => return Err(e),
+    }
+
+    let (candidates, skipped_chats) = sweep_rosters(client, base, query, max_chats).await?;
+    stages.push(StageReport {
+        stage: "roster".to_string(),
+        status: if candidates.is_empty() { "miss" } else { "hit" }.to_string(),
+        skipped_chats: (skipped_chats > 0).then_some(skipped_chats),
+    });
+    Ok(ResolveResult {
+        query: query.to_string(),
+        candidates,
+        stages,
+    })
+}
+
+/// Relevance-ranked people search via `/me/people`. Requires the People.Read
+/// delegated scope; Graph answers 403 without it. The search term must be
+/// wrapped in double quotes per the people API's `$search` contract.
+async fn search_people(client: &GraphClient, base: &str, query: &str) -> Result<Vec<Person>> {
+    let quoted = format!("\"{}\"", query.replace('"', ""));
+    let resp: PageResponse<Person> = client
+        .get(
+            &format!("{base}/me/people"),
+            &[("$search", quoted.as_str()), ("$top", "10")],
+        )
+        .await?;
+    Ok(resp.value)
+}
+
+/// Walk group and meeting chat rosters looking for the query, scanning up
+/// to `max_chats` chats and returning the candidates plus a count of
+/// rosters that couldn't be read. Colleagues cluster in shared meetings, so
+/// matches usually land early; a full-address email match ends the sweep
+/// after the current chat, but alias and name matches keep it scanning so
+/// namesakes in other chats aren't silently missed.
+async fn sweep_rosters(
+    client: &GraphClient,
+    base: &str,
+    query: &str,
+    max_chats: u64,
+) -> Result<(Vec<ResolveCandidate>, u64)> {
+    let pb = crate::output::progress::sweep_bar(max_chats);
+    let mut candidates: Vec<ResolveCandidate> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut confident = false;
+    let mut skipped = 0u64;
+    let mut scanned = 0u64;
+    let mut next: Option<String> = Some(format!("{base}/me/chats"));
+    let mut first_page = true;
+
+    'pages: while let Some(url) = next {
+        let page_query: &[(&str, &str)] = if first_page { &[("$top", "50")] } else { &[] };
+        first_page = false;
+        let page: PageResponse<Chat> = client.get(&url, page_query).await?;
+        next = page.next_link;
+
+        for chat in &page.value {
+            if scanned >= max_chats {
+                break 'pages;
+            }
+            let is_shared = matches!(chat.chat_type.as_deref(), Some("group") | Some("meeting"));
+            let Some(chat_id) = chat.id.as_deref().filter(|_| is_shared) else {
+                continue;
+            };
+            scanned += 1;
+            pb.inc(1);
+
+            // A single unreadable roster (403/404, e.g. a stale or
+            // restricted chat) shouldn't abort the whole sweep — count it
+            // and move on. Anything else (rate limiting, 5xx, network)
+            // means Graph is degraded, and continuing would let the caller
+            // mistake a partial sweep for a definitive miss.
+            let members: Vec<ConversationMember> = match client
+                .get_all_pages(&format!("{base}/chats/{chat_id}/members"), &[])
+                .await
+            {
+                Ok(members) => members,
+                Err(e @ (TeamsError::PermissionDenied(_) | TeamsError::NotFound(_))) => {
+                    tracing::warn!("skipping unreadable chat {chat_id}: {e}");
+                    skipped += 1;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            for m in &members {
+                if let Some(confidence) = member_match(query, m) {
+                    let key = m
+                        .user_id
+                        .clone()
+                        .or_else(|| m.email.clone())
+                        .unwrap_or_default();
+                    if seen.insert(key) {
+                        candidates.push(candidate_from_member(m));
+                    }
+                    if confidence == MatchConfidence::Email {
+                        confident = true;
+                    }
+                }
+            }
+            if confident {
+                break 'pages;
+            }
+        }
+    }
+
+    pb.finish_and_clear();
+    Ok((candidates, skipped))
+}
+
+/// A query is worth an exact `/users/{q}` lookup only when it could be a
+/// UPN or an object ID; display names contain whitespace and never match.
+fn looks_like_exact_reference(query: &str) -> bool {
+    !query.contains(char::is_whitespace) && (query.contains('@') || is_guid(query))
+}
+
+fn is_guid(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() == 36
+        && bytes.iter().enumerate().all(|(i, b)| match i {
+            8 | 13 | 18 | 23 => *b == b'-',
+            _ => b.is_ascii_hexdigit(),
+        })
+}
+
+/// A query containing '@' is an explicit address and only matches the
+/// member's full email, case-insensitively — matching on the local part
+/// alone could silently resolve jane@vendor.com to jane@corp.com. Bare
+/// queries match an email local part (e.g. "jsmith") or a display name in
+/// which every whitespace-separated token appears; both are suggestive
+/// rather than authoritative, since aliases and names collide across
+/// domains and people.
+fn member_match(query: &str, member: &ConversationMember) -> Option<MatchConfidence> {
+    let email = member.email.as_deref().unwrap_or_default();
+
+    if query.contains('@') {
+        return email
+            .eq_ignore_ascii_case(query)
+            .then_some(MatchConfidence::Email);
+    }
+
+    let member_local = email.split('@').next().unwrap_or_default();
+    if !member_local.is_empty() && member_local.eq_ignore_ascii_case(query) {
+        return Some(MatchConfidence::Name);
+    }
+
+    let name = member
+        .display_name
+        .as_deref()
+        .unwrap_or_default()
+        .to_lowercase();
+    (!name.is_empty()
+        && query
+            .split_whitespace()
+            .all(|token| name.contains(&token.to_lowercase())))
+    .then_some(MatchConfidence::Name)
+}
+
+fn stage(name: &str, status: &str) -> StageReport {
+    StageReport {
+        stage: name.to_string(),
+        status: status.to_string(),
+        skipped_chats: None,
+    }
+}
+
+fn is_forbidden(err: &TeamsError) -> bool {
+    matches!(
+        err,
+        TeamsError::PermissionDenied(_) | TeamsError::ApiError { status: 403, .. }
+    )
+}
+
+fn candidate_from_user(user: &User) -> ResolveCandidate {
+    ResolveCandidate {
+        id: user.id.clone(),
+        display_name: user.display_name.clone(),
+        mail: user.mail.clone(),
+        user_principal_name: user.user_principal_name.clone(),
+        job_title: user.job_title.clone(),
+        department: None,
+        via: "upn".to_string(),
+    }
+}
+
+fn candidate_from_person(person: &Person) -> ResolveCandidate {
+    let mail = person
+        .scored_email_addresses
+        .as_ref()
+        .and_then(|addrs| addrs.first())
+        .and_then(|a| a.address.clone());
+    ResolveCandidate {
+        id: person.id.clone(),
+        display_name: person.display_name.clone(),
+        mail,
+        user_principal_name: person.user_principal_name.clone(),
+        job_title: person.job_title.clone(),
+        department: person.department.clone(),
+        via: "people-search".to_string(),
+    }
+}
+
+fn candidate_from_member(member: &ConversationMember) -> ResolveCandidate {
+    ResolveCandidate {
+        id: member.user_id.clone(),
+        display_name: member.display_name.clone(),
+        mail: member.email.clone(),
+        user_principal_name: None,
+        job_title: None,
+        department: None,
+        via: "roster".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::token::TokenInfo;
+    use crate::config::NetworkConfig;
+    use reqwest::Client;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client() -> GraphClient {
+        GraphClient {
+            http: Client::new(),
+            token: TokenInfo {
+                access_token: "test-token".into(),
+                expires_at: None,
+                token_type: "Bearer".into(),
+                scope: None,
+                refresh_token: None,
+                profile: "default".into(),
+            },
+            network: NetworkConfig {
+                timeout: 30,
+                max_retries: 0,
+                retry_backoff_base: 2,
+            },
+        }
+    }
+
+    const GUID: &str = "99bb638b-5ca8-4bb9-8ee6-7a2d15dab139";
+
+    #[test]
+    fn exact_reference_detection() {
+        assert!(looks_like_exact_reference("someone@example.com"));
+        assert!(looks_like_exact_reference(GUID));
+        assert!(!looks_like_exact_reference("Jane Smith"));
+        assert!(!looks_like_exact_reference("jsmith"));
+        assert!(!looks_like_exact_reference("Jane Smith <jane@example.com>"));
+    }
+
+    #[test]
+    fn member_matching_rules() {
+        let member = ConversationMember {
+            id: None,
+            display_name: Some("Jane von Smith".into()),
+            roles: None,
+            user_id: Some("u1".into()),
+            email: Some("JSmith@example.com".into()),
+        };
+        assert_eq!(
+            member_match("jsmith@example.com", &member),
+            Some(MatchConfidence::Email)
+        );
+        // Same local part on a different domain is a different mailbox.
+        assert_eq!(member_match("jsmith@other-domain.com", &member), None);
+        // A bare alias is suggestive, never email-confident.
+        assert_eq!(member_match("jsmith", &member), Some(MatchConfidence::Name));
+        assert_eq!(
+            member_match("jane smith", &member),
+            Some(MatchConfidence::Name)
+        );
+        assert_eq!(member_match("SMITH", &member), Some(MatchConfidence::Name));
+        assert_eq!(member_match("jane.smith@example.com", &member), None);
+        assert_eq!(member_match("john smith", &member), None);
+    }
+
+    #[tokio::test]
+    async fn guid_query_resolves_via_exact_lookup_and_skips_other_stages() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/users/{GUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": GUID,
+                "displayName": "Abe Ingersoll",
+                "mail": "abe@example.com",
+                "userPrincipalName": "abe@example.com"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(&test_client(), &server.uri(), GUID, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].via, "upn");
+        assert_eq!(result.candidates[0].id.as_deref(), Some(GUID));
+        let statuses: Vec<(&str, &str)> = result
+            .stages
+            .iter()
+            .map(|s| (s.stage.as_str(), s.status.as_str()))
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                ("upn", "hit"),
+                ("people-search", "skipped"),
+                ("roster", "skipped")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn upn_miss_falls_through_to_people_search() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/ghost@example.com"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .and(query_param("$search", "\"ghost@example.com\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [{
+                    "id": "person-1",
+                    "displayName": "Ghost Writer",
+                    "userPrincipalName": "ghostw@example.com",
+                    "scoredEmailAddresses": [
+                        { "address": "ghost@example.com", "relevanceScore": 20.0 }
+                    ]
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(&test_client(), &server.uri(), "ghost@example.com", 10)
+            .await
+            .unwrap();
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].via, "people-search");
+        assert_eq!(
+            result.candidates[0].mail.as_deref(),
+            Some("ghost@example.com")
+        );
+        assert_eq!(result.stages[0].status, "miss");
+        assert_eq!(result.stages[1].status, "hit");
+        assert_eq!(result.stages[2].status, "skipped");
+    }
+
+    #[tokio::test]
+    async fn forbidden_people_search_degrades_to_roster_sweep_collecting_namesakes() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("no People.Read"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/chats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    { "id": "dm-1", "chatType": "oneOnOne" },
+                    { "id": "grp-1", "chatType": "group" },
+                    { "id": "grp-2", "chatType": "group" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-1/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "m1",
+                        "displayName": "Jane Smith",
+                        "userId": "u-jane",
+                        "email": "Springsteenw@example.com"
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // A bare-name match is not confident, so the sweep continues into
+        // grp-2 and picks up the namesake there too. u-jane reappearing in
+        // grp-2 must not produce a duplicate candidate.
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-2/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "m1b",
+                        "displayName": "Jane Smith",
+                        "userId": "u-jane",
+                        "email": "Springsteenw@example.com"
+                    },
+                    {
+                        "id": "m2",
+                        "displayName": "Jane Smith",
+                        "userId": "u-jane-2",
+                        "email": "jane.smith2@example.com"
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(&test_client(), &server.uri(), "jane smith", 10)
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = result
+            .candidates
+            .iter()
+            .map(|c| c.id.as_deref().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["u-jane", "u-jane-2"]);
+        assert!(result.candidates.iter().all(|c| c.via == "roster"));
+        let statuses: Vec<(&str, &str)> = result
+            .stages
+            .iter()
+            .map(|s| (s.stage.as_str(), s.status.as_str()))
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                ("upn", "skipped"),
+                ("people-search", "forbidden"),
+                ("roster", "hit")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn email_confident_roster_match_ends_sweep_early() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("no People.Read"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/chats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    { "id": "grp-1", "chatType": "group" },
+                    { "id": "grp-2", "chatType": "group" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-1/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "m1",
+                        "displayName": "Will Haynes",
+                        "userId": "u-will",
+                        "email": "Springsteenw@example.com"
+                    }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // A full-address match identifies one mailbox; grp-2 must not be
+        // fetched.
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-2/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": []
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(
+            &test_client(),
+            &server.uri(),
+            "springsteenw@example.com",
+            10,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].id.as_deref(), Some("u-will"));
+    }
+
+    #[tokio::test]
+    async fn sweep_respects_max_chats_bound() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": []
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/chats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    { "id": "grp-1", "chatType": "group" },
+                    { "id": "grp-2", "chatType": "group" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-1/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": []
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-2/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": []
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(&test_client(), &server.uri(), "nobody here", 1)
+            .await
+            .unwrap();
+
+        assert!(result.candidates.is_empty());
+        assert_eq!(result.stages[2].status, "miss");
+    }
+
+    #[tokio::test]
+    async fn unreadable_roster_is_skipped_not_fatal() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("no scope"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/chats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    { "id": "grp-bad", "chatType": "group" },
+                    { "id": "grp-good", "chatType": "meeting" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-bad/members"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("nope"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-good/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [
+                    {
+                        "id": "m1",
+                        "displayName": "Target Person",
+                        "userId": "u-target",
+                        "email": "target@example.com"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let result = resolve_user_at(&test_client(), &server.uri(), "target person", 10)
+            .await
+            .unwrap();
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].id.as_deref(), Some("u-target"));
+        let roster = result.stages.iter().find(|s| s.stage == "roster").unwrap();
+        assert_eq!(roster.skipped_chats, Some(1));
+    }
+
+    #[tokio::test]
+    async fn degraded_graph_during_sweep_propagates_instead_of_reporting_miss() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/me/people"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("no scope"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/me/chats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "value": [{ "id": "grp-1", "chatType": "group" }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chats/grp-1/members"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Graph is having a day"))
+            .mount(&server)
+            .await;
+
+        let err = resolve_user_at(&test_client(), &server.uri(), "somebody real", 10)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                TeamsError::ApiError { status: 500, .. } | TeamsError::ServerError { .. }
+            ),
+            "expected a server error, got: {err:?}"
+        );
+    }
+}

--- a/src/api/resolve.rs
+++ b/src/api/resolve.rs
@@ -93,7 +93,7 @@ pub(crate) async fn resolve_user_at(
 
     if looks_like_exact_reference(query) {
         match client
-            .get::<User>(&format!("{base}/users/{query}"), &[])
+            .get::<User>(&endpoints::user_at(base, query), &[])
             .await
         {
             Ok(user) => {
@@ -116,13 +116,13 @@ pub(crate) async fn resolve_user_at(
         stages.push(stage("upn", "skipped"));
     }
 
-    match search_people(client, base, query).await {
+    match search_people_candidates(client, base, query).await {
         Ok(people) if !people.is_empty() => {
             stages.push(stage("people-search", "hit"));
             stages.push(stage("roster", "skipped"));
             return Ok(ResolveResult {
                 query: query.to_string(),
-                candidates: people.iter().map(candidate_from_person).collect(),
+                candidates: people,
                 stages,
             });
         }
@@ -151,11 +151,70 @@ async fn search_people(client: &GraphClient, base: &str, query: &str) -> Result<
     let quoted = format!("\"{}\"", query.replace('"', ""));
     let resp: PageResponse<Person> = client
         .get(
-            &format!("{base}/me/people"),
+            &endpoints::my_people_at(base),
             &[("$search", quoted.as_str()), ("$top", "10")],
         )
         .await?;
-    Ok(resp.value)
+    Ok(resp
+        .value
+        .into_iter()
+        .filter(is_directory_user_person)
+        .collect())
+}
+
+async fn search_people_candidates(
+    client: &GraphClient,
+    base: &str,
+    query: &str,
+) -> Result<Vec<ResolveCandidate>> {
+    let people = search_people(client, base, query).await?;
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    for person in people {
+        let Some(upn) = person
+            .user_principal_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|upn| !upn.is_empty())
+        else {
+            continue;
+        };
+
+        match client
+            .get::<User>(&endpoints::user_at(base, upn), &[])
+            .await
+        {
+            Ok(user) => {
+                let key = user
+                    .id
+                    .clone()
+                    .or_else(|| user.user_principal_name.clone())
+                    .unwrap_or_else(|| upn.to_string());
+                if seen.insert(key) {
+                    let mut candidate = candidate_from_user(&user);
+                    candidate.via = "people-search".to_string();
+                    if candidate.job_title.is_none() {
+                        candidate.job_title = person.job_title.clone();
+                    }
+                    if candidate.department.is_none() {
+                        candidate.department = person.department.clone();
+                    }
+                    candidates.push(candidate);
+                }
+            }
+            Err(TeamsError::NotFound(_)) => continue,
+            Err(e) if is_forbidden(&e) => {
+                let key = upn.to_string();
+                if seen.insert(key) {
+                    candidates.push(candidate_from_person(&person));
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(candidates)
 }
 
 /// Walk group and meeting chat rosters looking for the query, scanning up
@@ -176,7 +235,7 @@ async fn sweep_rosters(
     let mut confident = false;
     let mut skipped = 0u64;
     let mut scanned = 0u64;
-    let mut next: Option<String> = Some(format!("{base}/me/chats"));
+    let mut next: Option<String> = Some(endpoints::my_chats_at(base));
     let mut first_page = true;
 
     'pages: while let Some(url) = next {
@@ -202,7 +261,7 @@ async fn sweep_rosters(
             // means Graph is degraded, and continuing would let the caller
             // mistake a partial sweep for a definitive miss.
             let members: Vec<ConversationMember> = match client
-                .get_all_pages(&format!("{base}/chats/{chat_id}/members"), &[])
+                .get_all_pages(&endpoints::chat_members_at(base, chat_id), &[])
                 .await
             {
                 Ok(members) => members,
@@ -302,6 +361,24 @@ fn is_forbidden(err: &TeamsError) -> bool {
     )
 }
 
+fn is_directory_user_person(person: &Person) -> bool {
+    let Some(person_type) = person.person_type.as_ref() else {
+        return person
+            .user_principal_name
+            .as_deref()
+            .is_some_and(|upn| !upn.trim().is_empty());
+    };
+
+    person_type
+        .class
+        .as_deref()
+        .is_some_and(|class| class.eq_ignore_ascii_case("Person"))
+        && person_type
+            .subclass
+            .as_deref()
+            .is_some_and(|subclass| subclass.eq_ignore_ascii_case("OrganizationUser"))
+}
+
 fn candidate_from_user(user: &User) -> ResolveCandidate {
     ResolveCandidate {
         id: user.id.clone(),
@@ -321,7 +398,11 @@ fn candidate_from_person(person: &Person) -> ResolveCandidate {
         .and_then(|addrs| addrs.first())
         .and_then(|a| a.address.clone());
     ResolveCandidate {
-        id: person.id.clone(),
+        // Microsoft documents person.id only as a people-resource identifier,
+        // not a directory user object ID. Use /users verification when we can;
+        // otherwise expose the UPN/mail without pretending the person id is a
+        // usable Teams user id.
+        id: None,
         display_name: person.display_name.clone(),
         mail,
         user_principal_name: person.user_principal_name.clone(),
@@ -348,6 +429,7 @@ mod tests {
     use super::*;
     use crate::auth::token::TokenInfo;
     use crate::config::NetworkConfig;
+    use crate::models::user::PersonType;
     use reqwest::Client;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -408,6 +490,65 @@ mod tests {
         assert_eq!(member_match("john smith", &member), None);
     }
 
+    #[test]
+    fn people_search_filter_keeps_directory_users_only() {
+        let org_user = Person {
+            id: Some("u1".into()),
+            display_name: Some("Jane User".into()),
+            user_principal_name: Some("jane@example.com".into()),
+            job_title: None,
+            department: None,
+            scored_email_addresses: None,
+            person_type: Some(PersonType {
+                class: Some("Person".into()),
+                subclass: Some("OrganizationUser".into()),
+            }),
+            extra: serde_json::Value::Null,
+        };
+        let group = Person {
+            id: Some("g1".into()),
+            display_name: Some("Marketing".into()),
+            user_principal_name: None,
+            job_title: None,
+            department: None,
+            scored_email_addresses: None,
+            person_type: Some(PersonType {
+                class: Some("Group".into()),
+                subclass: Some("UnifiedGroup".into()),
+            }),
+            extra: serde_json::Value::Null,
+        };
+        let contact = Person {
+            id: Some("c1".into()),
+            display_name: Some("External Contact".into()),
+            user_principal_name: None,
+            job_title: None,
+            department: None,
+            scored_email_addresses: None,
+            person_type: Some(PersonType {
+                class: Some("Person".into()),
+                subclass: Some("PersonalContact".into()),
+            }),
+            extra: serde_json::Value::Null,
+        };
+        let no_type_with_upn = Person {
+            id: Some("u2".into()),
+            display_name: Some("Legacy User".into()),
+            user_principal_name: Some("legacy@example.com".into()),
+            job_title: None,
+            department: None,
+            scored_email_addresses: None,
+            person_type: None,
+            extra: serde_json::Value::Null,
+        };
+
+        assert!(is_directory_user_person(&org_user));
+        assert!(!is_directory_user_person(&group));
+        assert!(!is_directory_user_person(&contact));
+        assert!(is_directory_user_person(&no_type_with_upn));
+        assert_eq!(candidate_from_person(&org_user).id, None);
+    }
+
     #[tokio::test]
     async fn guid_query_resolves_via_exact_lookup_and_skips_other_stages() {
         let server = MockServer::start().await;
@@ -457,15 +598,43 @@ mod tests {
             .and(path("/me/people"))
             .and(query_param("$search", "\"ghost@example.com\""))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "value": [{
-                    "id": "person-1",
-                    "displayName": "Ghost Writer",
-                    "userPrincipalName": "ghostw@example.com",
-                    "scoredEmailAddresses": [
-                        { "address": "ghost@example.com", "relevanceScore": 20.0 }
-                    ]
-                }]
+                "value": [
+                    {
+                        "id": "group-1",
+                        "displayName": "Ghost Writers",
+                        "personType": {
+                            "class": "Group",
+                            "subclass": "UnifiedGroup"
+                        },
+                        "scoredEmailAddresses": [
+                            { "address": "ghosts@example.com", "relevanceScore": 30.0 }
+                        ]
+                    },
+                    {
+                        "id": "person-1",
+                        "displayName": "Ghost Writer",
+                        "userPrincipalName": "ghostw@example.com",
+                        "personType": {
+                            "class": "Person",
+                            "subclass": "OrganizationUser"
+                        },
+                        "scoredEmailAddresses": [
+                            { "address": "ghost@example.com", "relevanceScore": 20.0 }
+                        ]
+                    }
+                ]
             })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/users/ghostw@example.com"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "user-1",
+                "displayName": "Ghost Writer",
+                "mail": "ghost@example.com",
+                "userPrincipalName": "ghostw@example.com"
+            })))
+            .expect(1)
             .mount(&server)
             .await;
 
@@ -475,6 +644,7 @@ mod tests {
 
         assert_eq!(result.candidates.len(), 1);
         assert_eq!(result.candidates[0].via, "people-search");
+        assert_eq!(result.candidates[0].id.as_deref(), Some("user-1"));
         assert_eq!(
             result.candidates[0].mail.as_deref(),
             Some("ghost@example.com")

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -7,7 +7,7 @@ pub mod token;
 
 use chrono::{Duration, Utc};
 
-use crate::config::DEFAULT_DELEGATED_SCOPES;
+use crate::config::{ensure_offline_access, DEFAULT_DELEGATED_SCOPES};
 use crate::error::{Result, TeamsError};
 use token::TokenInfo;
 
@@ -128,13 +128,7 @@ fn refreshed_token_info(
 /// back to the default delegated scopes.
 fn refresh_scope(existing: Option<&str>) -> String {
     match existing {
-        Some(scope) if !scope.trim().is_empty() => {
-            if scope.split_whitespace().any(|s| s == "offline_access") {
-                scope.to_string()
-            } else {
-                format!("{scope} offline_access")
-            }
-        }
+        Some(scope) if !scope.trim().is_empty() => ensure_offline_access(scope),
         _ => DEFAULT_DELEGATED_SCOPES.to_string(),
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -79,6 +79,58 @@ fn handle_refresh_failure(info: &TokenInfo, error: TeamsError) -> Result<TokenIn
 /// cannot be refreshed — e.g. no refresh token, undecodable claims, or the
 /// identity platform rejecting the request.
 async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
+    let scope = refresh_scope(info.scope.as_deref());
+    let refreshed = redeem_refresh_token(profile, info, &scope).await?;
+
+    // Best-effort persistence so the next invocation reuses the new token.
+    let _ = keyring::store_token(profile, &refreshed);
+
+    Ok(refreshed)
+}
+
+/// Redeem the stored refresh token for a delegated scope string, no
+/// interactive login. Refresh tokens are bound to user + client, not to the
+/// originally requested scopes, so this succeeds for any scope set already
+/// consented for the app — the mechanism behind `teams auth refresh` picking
+/// up newly admin-consented permissions silently. An unconsented scope makes
+/// the identity platform reject the whole request (AADSTS65001) rather than
+/// return a narrower token.
+///
+/// Without an explicit `scope` override the stored token's scope is reused,
+/// so a plain refresh never down-scopes a token that was minted with more
+/// than the defaults. Returns the scope string that was requested alongside
+/// the refreshed token.
+pub async fn refresh_token_with_scopes(
+    profile: &str,
+    scope: Option<&str>,
+) -> Result<(TokenInfo, String)> {
+    let info = keyring::get_token(profile).map_err(|_| {
+        TeamsError::AuthError("Not authenticated. Run `teams auth login` first.".into())
+    })?;
+
+    if info.refresh_token.is_none() {
+        return Err(TeamsError::AuthError(
+            "Stored token has no refresh token to redeem. Run `teams auth login` first.".into(),
+        ));
+    }
+
+    let scope = match scope {
+        Some(explicit) => explicit.to_string(),
+        None => refresh_scope(info.scope.as_deref()),
+    };
+
+    let refreshed = redeem_refresh_token(profile, &info, &scope).await?;
+
+    // The upgraded token is the whole point of the command, so a persistence
+    // failure is a hard error here, unlike the best-effort background refresh.
+    keyring::store_token(profile, &refreshed)?;
+
+    Ok((refreshed, scope))
+}
+
+/// Redeem the stored refresh token for the given scope string. Does not
+/// persist the result; callers decide whether storage failures are fatal.
+async fn redeem_refresh_token(profile: &str, info: &TokenInfo, scope: &str) -> Result<TokenInfo> {
     let refresh_token = info
         .refresh_token
         .as_deref()
@@ -93,16 +145,10 @@ async fn attempt_refresh(profile: &str, info: &TokenInfo) -> Result<TokenInfo> {
         .or(claims.appid)
         .ok_or(TeamsError::TokenExpired)?;
 
-    let scope = refresh_scope(info.scope.as_deref());
-
     let response =
-        refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, &scope).await?;
-    let refreshed = refreshed_token_info(profile, info, response);
+        refresh::refresh_access_token(&client_id, &tenant_id, refresh_token, scope).await?;
 
-    // Best-effort persistence so the next invocation reuses the new token.
-    let _ = keyring::store_token(profile, &refreshed);
-
-    Ok(refreshed)
+    Ok(refreshed_token_info(profile, info, response))
 }
 
 fn refreshed_token_info(

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -34,6 +34,12 @@ pub enum AuthCommand {
         #[arg(long, env = "TEAMS_CLI_SCOPES")]
         scopes: Option<String>,
     },
+    /// Silently redeem the stored refresh token for the resolved delegated scopes
+    Refresh {
+        /// OAuth scopes (space-separated, for delegated flows)
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
+        scopes: Option<String>,
+    },
     /// Check current auth status
     Status,
     /// Print the admin consent URL for the active auth app
@@ -45,6 +51,10 @@ pub enum AuthCommand {
         /// Azure AD tenant ID or domain
         #[arg(long, env = "TEAMS_CLI_TENANT_ID")]
         tenant_id: Option<String>,
+
+        /// OAuth scopes (space-separated) to include in the consent URL
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
+        scopes: Option<String>,
     },
     /// Diagnose auth configuration and current token state
     Doctor {
@@ -124,6 +134,36 @@ fn graph_admin_consent_scopes(scopes: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Turn the identity platform's consent-required rejection (AADSTS65001) of a
+/// refresh-token redemption into actionable guidance. The platform rejects the
+/// whole request when any requested scope lacks consent; it never returns a
+/// narrower token. When an explicit scope override failed, the guidance names
+/// it so the consent URL covers the exact scope set that was rejected.
+fn annotate_consent_error(
+    error: TeamsError,
+    profile: &str,
+    requested_scopes: Option<&str>,
+) -> TeamsError {
+    match error {
+        TeamsError::AuthError(message)
+            if message.contains("AADSTS65001") || message.contains("consent_required") =>
+        {
+            let consent_command = match requested_scopes {
+                Some(scopes) => {
+                    format!("teams --profile {profile} auth consent-url --scopes \"{scopes}\"")
+                }
+                None => format!("teams --profile {profile} auth consent-url"),
+            };
+            TeamsError::AuthError(format!(
+                "{message}\n\nThe requested scopes have not been consented for this app. \
+                 Grant admin consent (run `{consent_command}` for the URL) and retry, or run \
+                 `teams --profile {profile} auth login` for interactive consent."
+            ))
+        }
+        other => other,
+    }
 }
 
 fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
@@ -207,16 +247,40 @@ pub async fn run(
             Ok(())
         }
 
+        AuthCommand::Refresh { scopes } => {
+            let start = Instant::now();
+            // No explicit override means the stored token's scope is reused,
+            // so a plain refresh never down-scopes a previously broader login.
+            let override_scopes =
+                config::resolve_delegated_scopes_override(scopes.as_deref(), profile, config);
+
+            let (token_info, requested_scope) =
+                auth::refresh_token_with_scopes(profile, override_scopes.as_deref())
+                    .await
+                    .map_err(|e| annotate_consent_error(e, profile, override_scopes.as_deref()))?;
+
+            let msg = serde_json::json!({
+                "message": "Token refreshed successfully",
+                "profile": profile,
+                "requested_scope": requested_scope,
+                "granted_scope": token_info.scope,
+                "expires_at": token_info.expires_at.map(|e| e.to_rfc3339()),
+            });
+            output::print_success(format, &msg, start);
+            Ok(())
+        }
+
         AuthCommand::ConsentUrl {
             client_id,
             tenant_id,
+            scopes,
         } => {
             let start = Instant::now();
             let client_id =
                 config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
             let tenant_id =
                 config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-            let scopes = config::resolve_delegated_scopes(None, profile, config);
+            let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
             let url = delegated_admin_consent_url(&client_id, &tenant_id, &scopes);
             let msg = serde_json::json!({
                 "admin_consent_url": url,
@@ -384,5 +448,47 @@ pub async fn run(
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn annotate_consent_error_adds_guidance_with_requested_scopes() {
+        let error = TeamsError::AuthError("Token refresh failed: AADSTS65001: no consent".into());
+        let annotated = annotate_consent_error(error, "work", Some("User.Read People.Read"));
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(message.contains("AADSTS65001"));
+        assert!(message
+            .contains("teams --profile work auth consent-url --scopes \"User.Read People.Read\""));
+        assert!(message.contains("--profile work auth login"));
+    }
+
+    #[test]
+    fn annotate_consent_error_omits_scopes_flag_without_override() {
+        let error = TeamsError::AuthError("consent_required".into());
+        let annotated = annotate_consent_error(error, "default", None);
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(message.contains("`teams --profile default auth consent-url`"));
+        assert!(!message.contains("--scopes"));
+    }
+
+    #[test]
+    fn annotate_consent_error_passes_through_other_errors() {
+        let error = TeamsError::AuthError("Token refresh failed: AADSTS70008 expired".into());
+        let annotated = annotate_consent_error(error, "default", None);
+
+        let TeamsError::AuthError(message) = annotated else {
+            panic!("expected AuthError");
+        };
+        assert!(!message.contains("consent-url"));
     }
 }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -31,7 +31,7 @@ pub enum AuthCommand {
         tenant_id: Option<String>,
 
         /// OAuth scopes (space-separated, for delegated flows)
-        #[arg(long)]
+        #[arg(long, env = "TEAMS_CLI_SCOPES")]
         scopes: Option<String>,
     },
     /// Check current auth status
@@ -126,8 +126,8 @@ fn graph_admin_consent_scopes(scopes: &str) -> String {
         .join(" ")
 }
 
-fn delegated_admin_consent_url(client_id: &str, tenant_id: &str) -> String {
-    let scopes = graph_admin_consent_scopes(config::DEFAULT_DELEGATED_SCOPES);
+fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
+    let scopes = graph_admin_consent_scopes(delegated_scopes);
     format!(
         "https://login.microsoftonline.com/{tenant_id}/v2.0/adminconsent?client_id={client_id}&scope={}&redirect_uri={}",
         urlencoding::encode(&scopes),
@@ -179,15 +179,16 @@ pub async fn run(
                     config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
                 let tenant_id =
                     config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-                auth::device_code::authenticate(&client_id, &tenant_id, scopes.as_deref()).await?
+                let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
+                auth::device_code::authenticate(&client_id, &tenant_id, Some(&scopes)).await?
             } else {
                 // Default: auth code + PKCE
                 let client_id =
                     config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
                 let tenant_id =
                     config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-                auth::auth_code_pkce::authenticate(&client_id, &tenant_id, scopes.as_deref())
-                    .await?
+                let scopes = config::resolve_delegated_scopes(scopes.as_deref(), profile, config);
+                auth::auth_code_pkce::authenticate(&client_id, &tenant_id, Some(&scopes)).await?
             };
 
             let token_info = token_response.into_token_info(profile);
@@ -215,12 +216,13 @@ pub async fn run(
                 config::resolve_delegated_client_id(client_id.as_deref(), profile, config)?;
             let tenant_id =
                 config::resolve_delegated_tenant_id(tenant_id.as_deref(), profile, config);
-            let url = delegated_admin_consent_url(&client_id, &tenant_id);
+            let scopes = config::resolve_delegated_scopes(None, profile, config);
+            let url = delegated_admin_consent_url(&client_id, &tenant_id, &scopes);
             let msg = serde_json::json!({
                 "admin_consent_url": url,
                 "client_id": client_id,
                 "tenant_id": tenant_id,
-                "scope": config::DEFAULT_DELEGATED_SCOPES,
+                "scope": scopes,
                 "redirect_uri": config::DEFAULT_REDIRECT_URI,
             });
             output::print_success(format, &msg, start);
@@ -245,7 +247,9 @@ pub async fn run(
             let token = auth::resolve_token(profile).await.ok();
             let claims = token.as_ref().and_then(|t| t.unverified_claims());
             let warnings = token_warnings(claims.as_ref());
-            let admin_consent_url = delegated_admin_consent_url(&client_id, &tenant_id);
+            let resolved_scopes = config::resolve_delegated_scopes(None, profile, config);
+            let admin_consent_url =
+                delegated_admin_consent_url(&client_id, &tenant_id, &resolved_scopes);
             let msg = serde_json::json!({
                 "profile": profile,
                 "auth_app": auth_app,
@@ -253,6 +257,7 @@ pub async fn run(
                 "tenant_id": tenant_id,
                 "admin_consent_url": admin_consent_url,
                 "default_delegated_scopes": config::DEFAULT_DELEGATED_SCOPES,
+                "resolved_delegated_scopes": resolved_scopes,
                 "redirect_uri": config::DEFAULT_REDIRECT_URI,
                 "authenticated": token.is_some(),
                 "warnings": warnings,

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -66,6 +66,14 @@ pub enum MessageCommand {
             conflicts_with = "message_id"
         )]
         message: Option<String>,
+        /// Include an inventory of attachments and inline images
+        #[arg(long)]
+        with_attachments: bool,
+    },
+    /// List or download message attachments and inline images
+    Attachments {
+        #[command(subcommand)]
+        command: super::message_attachments::AttachmentsCommand,
     },
     /// Reply to a channel message
     Reply {
@@ -334,13 +342,34 @@ pub async fn run(
             channel,
             message_id,
             message,
+            with_attachments,
         } => {
             let start = Instant::now();
             let message_id = resolve_id(message_id, message, "--message or <MESSAGE_ID>")?;
             let msg =
                 api::messages::get_channel_message(&client, &team, &channel, &message_id).await?;
-            output::print_success(format, &msg, start);
+            if with_attachments {
+                let message_ref = api::messages::MessageRef::Channel {
+                    team_id: team,
+                    channel_id: channel,
+                    message_id,
+                };
+                let hosted = api::messages::list_hosted_contents(&client, &message_ref).await?;
+                let items = crate::models::attachment_inventory::build_inventory(&msg, &hosted);
+                let mut value = serde_json::to_value(&msg).map_err(|e| TeamsError::ApiError {
+                    status: 0,
+                    message: format!("Failed to serialize message: {e}"),
+                })?;
+                value["attachment_items"] = serde_json::to_value(items).unwrap_or_default();
+                output::print_success(format, &value, start);
+            } else {
+                output::print_success(format, &msg, start);
+            }
             Ok(())
+        }
+
+        MessageCommand::Attachments { command } => {
+            super::message_attachments::run(command, &client, format).await
         }
 
         MessageCommand::Reply {
@@ -461,7 +490,11 @@ pub async fn run(
     }
 }
 
-fn resolve_id(positional: Option<String>, named: Option<String>, expected: &str) -> Result<String> {
+pub(crate) fn resolve_id(
+    positional: Option<String>,
+    named: Option<String>,
+    expected: &str,
+) -> Result<String> {
     match (positional, named) {
         (Some(_), Some(_)) => Err(TeamsError::InvalidInput(format!(
             "Provide only one of {expected}"
@@ -501,7 +534,10 @@ fn build_send_request(
             id: Some(uuid::Uuid::new_v4().to_string()),
             content_type: Some("application/vnd.microsoft.card.adaptive".to_string()),
             content: Some(card_json),
+            content_url: None,
             name: None,
+            thumbnail_url: None,
+            teams_app_id: None,
         }])
     } else {
         None

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -34,6 +34,12 @@ pub enum MessageCommand {
         /// Path to adaptive card JSON file
         #[arg(long)]
         adaptive_card: Option<String>,
+        /// Image file to send inline, like a pasted screenshot (repeatable)
+        #[arg(long)]
+        image: Vec<String>,
+        /// File to upload and attach (repeatable; needs a Files.ReadWrite scope)
+        #[arg(long)]
+        attach: Vec<String>,
     },
     /// List messages in a channel or chat
     List {
@@ -95,6 +101,12 @@ pub enum MessageCommand {
         /// Content type: text or html
         #[arg(long, default_value = "text")]
         content_type: String,
+        /// Image file to send inline, like a pasted screenshot (repeatable)
+        #[arg(long)]
+        image: Vec<String>,
+        /// File to upload and attach (repeatable; needs a Files.ReadWrite scope)
+        #[arg(long)]
+        attach: Vec<String>,
     },
     /// Add a reaction to a message (beta)
     React {
@@ -258,14 +270,25 @@ pub async fn run(
             stdin,
             content_type,
             adaptive_card,
+            image,
+            attach,
         } => {
             let start = Instant::now();
             auth::require_delegated_token(&client.token, "Sending Teams messages")?;
 
-            let content = resolve_body(body, stdin)?;
-            let req = build_send_request(content, &content_type, adaptive_card.as_deref())?;
+            let has_media = !image.is_empty() || !attach.is_empty();
+            let content = resolve_body_or_media(body, stdin, has_media)?;
+            let mut req = build_send_request(content, &content_type, adaptive_card.as_deref())?;
 
             let msg = if let Some(chat_id) = chat {
+                super::message_media::apply_media(
+                    &client,
+                    &mut req,
+                    &image,
+                    &attach,
+                    super::message_media::AttachDestination::Chat,
+                )
+                .await?;
                 api::messages::send_chat_message(&client, &chat_id, &req).await?
             } else {
                 let team_id = team.ok_or_else(|| {
@@ -277,6 +300,17 @@ pub async fn run(
                 let channel_id = channel.ok_or_else(|| {
                     TeamsError::InvalidInput("--channel is required for channel messages".into())
                 })?;
+                super::message_media::apply_media(
+                    &client,
+                    &mut req,
+                    &image,
+                    &attach,
+                    super::message_media::AttachDestination::Channel {
+                        team_id: &team_id,
+                        channel_id: &channel_id,
+                    },
+                )
+                .await?;
                 api::messages::send_channel_message(&client, &team_id, &channel_id, &req).await?
             };
             output::print_success(format, &msg, start);
@@ -379,11 +413,25 @@ pub async fn run(
             body,
             stdin,
             content_type,
+            image,
+            attach,
         } => {
             let start = Instant::now();
             auth::require_delegated_token(&client.token, "Replying to Teams messages")?;
-            let content = resolve_body(body, stdin)?;
-            let req = build_send_request(content, &content_type, None)?;
+            let has_media = !image.is_empty() || !attach.is_empty();
+            let content = resolve_body_or_media(body, stdin, has_media)?;
+            let mut req = build_send_request(content, &content_type, None)?;
+            super::message_media::apply_media(
+                &client,
+                &mut req,
+                &image,
+                &attach,
+                super::message_media::AttachDestination::Channel {
+                    team_id: &team,
+                    channel_id: &channel,
+                },
+            )
+            .await?;
             let msg = api::messages::reply_to_message(&client, &team, &channel, &message_id, &req)
                 .await?;
             output::print_success(format, &msg, start);
@@ -518,6 +566,15 @@ fn resolve_body(body: Option<String>, stdin: bool) -> Result<String> {
     }
 }
 
+/// A body is required unless the message carries media (`--image`/`--attach`),
+/// in which case it may be empty.
+fn resolve_body_or_media(body: Option<String>, stdin: bool, has_media: bool) -> Result<String> {
+    if body.is_none() && !stdin && has_media {
+        return Ok(String::new());
+    }
+    resolve_body(body, stdin)
+}
+
 fn build_send_request(
     content: String,
     content_type: &str,
@@ -549,5 +606,6 @@ fn build_send_request(
             content: Some(content),
         },
         attachments,
+        hosted_contents: None,
     })
 }

--- a/src/cli/message_attachments.rs
+++ b/src/cli/message_attachments.rs
@@ -1,0 +1,558 @@
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use clap::Subcommand;
+
+use crate::api::messages::MessageRef;
+use crate::api::{self, GraphClient};
+use crate::error::{Result, TeamsError};
+use crate::models::attachment_inventory::{build_inventory, AttachmentItem, ItemKind};
+use crate::output::{self, OutputFormat};
+
+#[derive(Debug, Subcommand)]
+pub enum AttachmentsCommand {
+    /// List attachments and inline images in a message
+    List {
+        /// Team ID (for channel messages)
+        #[arg(long)]
+        team: Option<String>,
+        /// Channel ID (for channel messages)
+        #[arg(long)]
+        channel: Option<String>,
+        /// Chat ID (for chat messages)
+        #[arg(long)]
+        chat: Option<String>,
+        /// Reply ID (for a reply within a channel thread)
+        #[arg(long)]
+        reply: Option<String>,
+        /// Message ID
+        #[arg(required_unless_present = "message", conflicts_with = "message")]
+        message_id: Option<String>,
+        /// Message ID
+        #[arg(
+            long = "message",
+            alias = "message-id",
+            required_unless_present = "message_id",
+            conflicts_with = "message_id"
+        )]
+        message: Option<String>,
+    },
+    /// Download attachments and inline images from a message
+    Download {
+        /// Team ID (for channel messages)
+        #[arg(long)]
+        team: Option<String>,
+        /// Channel ID (for channel messages)
+        #[arg(long)]
+        channel: Option<String>,
+        /// Chat ID (for chat messages)
+        #[arg(long)]
+        chat: Option<String>,
+        /// Reply ID (for a reply within a channel thread)
+        #[arg(long)]
+        reply: Option<String>,
+        /// Message ID
+        #[arg(required_unless_present = "message", conflicts_with = "message")]
+        message_id: Option<String>,
+        /// Message ID
+        #[arg(
+            long = "message",
+            alias = "message-id",
+            required_unless_present = "message_id",
+            conflicts_with = "message_id"
+        )]
+        message: Option<String>,
+        /// Download only the item with this index (from `attachments list`)
+        #[arg(long)]
+        index: Option<usize>,
+        /// Output directory for downloaded files
+        #[arg(long, conflicts_with = "path")]
+        dir: Option<String>,
+        /// Exact output file path for a single item; use '-' for stdout
+        #[arg(long, requires = "index")]
+        path: Option<String>,
+    },
+}
+
+pub async fn run(
+    cmd: AttachmentsCommand,
+    client: &GraphClient,
+    format: OutputFormat,
+) -> Result<()> {
+    match cmd {
+        AttachmentsCommand::List {
+            team,
+            channel,
+            chat,
+            reply,
+            message_id,
+            message,
+        } => {
+            let start = Instant::now();
+            let message_id =
+                super::message::resolve_id(message_id, message, "--message or <MESSAGE_ID>")?;
+            let message_ref = resolve_message_ref(team, channel, chat, reply, message_id.clone())?;
+            let items = fetch_inventory(client, &message_ref).await?;
+            let result = serde_json::json!({
+                "message_id": message_id,
+                "items": items,
+            });
+            output::print_success(format, &result, start);
+            Ok(())
+        }
+
+        AttachmentsCommand::Download {
+            team,
+            channel,
+            chat,
+            reply,
+            message_id,
+            message,
+            index,
+            dir,
+            path,
+        } => {
+            let start = Instant::now();
+            let message_id =
+                super::message::resolve_id(message_id, message, "--message or <MESSAGE_ID>")?;
+            let message_ref = resolve_message_ref(team, channel, chat, reply, message_id.clone())?;
+            let items = fetch_inventory(client, &message_ref).await?;
+            let selected = select_items(&items, index)?;
+
+            if path.as_deref() == Some("-") {
+                let item = selected[0];
+                let (bytes, _) = fetch_item_bytes(client, &message_ref, item).await?;
+                std::io::stdout().write_all(&bytes).map_err(|e| {
+                    TeamsError::InvalidInput(format!("Failed to write stdout: {e}"))
+                })?;
+                return Ok(());
+            }
+
+            let dir = PathBuf::from(dir.unwrap_or_else(|| ".".to_string()));
+            let mut results = Vec::new();
+            let mut first_error: Option<TeamsError> = None;
+            for item in &selected {
+                match download_item(
+                    client,
+                    &message_ref,
+                    &message_id,
+                    item,
+                    &dir,
+                    path.as_deref(),
+                )
+                .await
+                {
+                    Ok(saved) => results.push(saved),
+                    Err(e) => {
+                        results.push(serde_json::json!({
+                            "index": item.index,
+                            "kind": item.kind,
+                            "error": e.to_string(),
+                        }));
+                        first_error.get_or_insert(e);
+                    }
+                }
+            }
+
+            if let Some(err) = first_error {
+                let saved: Vec<&str> = results
+                    .iter()
+                    .filter_map(|r| r.get("path").and_then(|p| p.as_str()))
+                    .collect();
+                let saved_note = if saved.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        " Successfully downloaded before the failure: {}.",
+                        saved.join(", ")
+                    )
+                };
+                return Err(augment_error(err, &saved_note));
+            }
+
+            let result = serde_json::json!({
+                "message_id": message_id,
+                "downloaded": results,
+            });
+            output::print_success(format, &result, start);
+            Ok(())
+        }
+    }
+}
+
+/// Fetch the message and its hosted contents, returning the unified inventory.
+pub async fn fetch_inventory(
+    client: &GraphClient,
+    message_ref: &MessageRef,
+) -> Result<Vec<AttachmentItem>> {
+    let msg = api::messages::get_message(client, message_ref).await?;
+    let hosted = api::messages::list_hosted_contents(client, message_ref).await?;
+    Ok(build_inventory(&msg, &hosted))
+}
+
+fn resolve_message_ref(
+    team: Option<String>,
+    channel: Option<String>,
+    chat: Option<String>,
+    reply: Option<String>,
+    message_id: String,
+) -> Result<MessageRef> {
+    match (chat, team, channel) {
+        (Some(chat_id), None, None) => {
+            if reply.is_some() {
+                return Err(TeamsError::InvalidInput(
+                    "--reply only applies to channel messages".into(),
+                ));
+            }
+            Ok(MessageRef::Chat {
+                chat_id,
+                message_id,
+            })
+        }
+        (None, Some(team_id), Some(channel_id)) => Ok(match reply {
+            Some(reply_id) => MessageRef::ChannelReply {
+                team_id,
+                channel_id,
+                message_id,
+                reply_id,
+            },
+            None => MessageRef::Channel {
+                team_id,
+                channel_id,
+                message_id,
+            },
+        }),
+        _ => Err(TeamsError::InvalidInput(
+            "Provide either --chat, or both --team and --channel".into(),
+        )),
+    }
+}
+
+fn select_items(items: &[AttachmentItem], index: Option<usize>) -> Result<Vec<&AttachmentItem>> {
+    match index {
+        Some(i) => {
+            let item = items.iter().find(|it| it.index == i).ok_or_else(|| {
+                TeamsError::InvalidInput(format!(
+                    "No attachment item with index {i}; the message has {} item(s). \
+                     Run `teams message attachments list` to see them.",
+                    items.len()
+                ))
+            })?;
+            if !item.downloadable {
+                return Err(TeamsError::InvalidInput(format!(
+                    "Item {i} ({:?}) is not downloadable; its content is inline in `message get` output.",
+                    item.kind
+                )));
+            }
+            Ok(vec![item])
+        }
+        None => {
+            let downloadable: Vec<&AttachmentItem> =
+                items.iter().filter(|it| it.downloadable).collect();
+            if downloadable.is_empty() {
+                return Err(TeamsError::NotFound(
+                    "Message has no downloadable attachments or inline images".into(),
+                ));
+            }
+            Ok(downloadable)
+        }
+    }
+}
+
+async fn fetch_item_bytes(
+    client: &GraphClient,
+    message_ref: &MessageRef,
+    item: &AttachmentItem,
+) -> Result<(Vec<u8>, Option<String>)> {
+    match item.kind {
+        ItemKind::HostedContent => {
+            let id = item.hosted_content_id.as_deref().ok_or_else(|| {
+                TeamsError::InvalidInput("Hosted content item is missing its ID".into())
+            })?;
+            api::messages::get_hosted_content_bytes(client, message_ref, id).await
+        }
+        ItemKind::CodeSnippet => {
+            let url = item.code_snippet_url.as_deref().ok_or_else(|| {
+                TeamsError::InvalidInput("Code snippet item is missing codeSnippetUrl".into())
+            })?;
+            let id = code_snippet_hosted_content_id(url).ok_or_else(|| {
+                TeamsError::InvalidInput(format!(
+                    "Code snippet codeSnippetUrl is not a Graph hostedContents URL, \
+                     refusing to fetch it: {url}"
+                ))
+            })?;
+            api::messages::get_hosted_content_bytes(client, message_ref, &id).await
+        }
+        ItemKind::FileReference => {
+            let url = item.content_url.as_deref().ok_or_else(|| {
+                TeamsError::InvalidInput("File attachment is missing contentUrl".into())
+            })?;
+            api::files::download_shared_item(client, url).await
+        }
+        _ => Err(TeamsError::InvalidInput(format!(
+            "Item {} ({:?}) is not downloadable",
+            item.index, item.kind
+        ))),
+    }
+}
+
+/// Extract the hosted-content ID from a `codeSnippetUrl`. The URL is message
+/// content an arbitrary sender controls, so it is never fetched directly —
+/// doing so would send our Graph bearer token wherever it points. Only the ID
+/// is taken, percent-decoded, and the request URL is rebuilt from the message
+/// reference we already resolved.
+fn code_snippet_hosted_content_id(url: &str) -> Option<String> {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let mut segments = path.split('/').skip_while(|s| *s != "hostedContents");
+    segments.next()?;
+    let id = segments.next().filter(|s| !s.is_empty())?;
+    if segments.next() != Some("$value") || segments.next().is_some() {
+        return None;
+    }
+    urlencoding::decode(id).ok().map(|s| s.into_owned())
+}
+
+async fn download_item(
+    client: &GraphClient,
+    message_ref: &MessageRef,
+    message_id: &str,
+    item: &AttachmentItem,
+    dir: &Path,
+    explicit_path: Option<&str>,
+) -> Result<serde_json::Value> {
+    let (bytes, content_type) = fetch_item_bytes(client, message_ref, item).await?;
+
+    let target = match explicit_path {
+        Some(p) => PathBuf::from(p),
+        None => unique_path(dir.join(default_filename(message_id, item, content_type.as_deref()))),
+    };
+
+    write_atomically(&target, &bytes)?;
+
+    Ok(serde_json::json!({
+        "index": item.index,
+        "kind": item.kind,
+        "path": target.to_string_lossy(),
+        "size": bytes.len(),
+        "content_type": content_type,
+    }))
+}
+
+fn default_filename(message_id: &str, item: &AttachmentItem, content_type: Option<&str>) -> String {
+    match item.kind {
+        ItemKind::FileReference => item
+            .name
+            .as_deref()
+            .map(sanitize_filename)
+            .unwrap_or_else(|| format!("msg-{message_id}-{}.bin", item.index)),
+        ItemKind::CodeSnippet => format!("msg-{message_id}-{}.txt", item.index),
+        _ => format!(
+            "msg-{message_id}-{}.{}",
+            item.index,
+            extension_for(content_type)
+        ),
+    }
+}
+
+fn extension_for(content_type: Option<&str>) -> &'static str {
+    match content_type {
+        Some("image/png") => "png",
+        Some("image/jpeg") => "jpg",
+        Some("image/gif") => "gif",
+        Some("image/webp") => "webp",
+        Some("image/bmp") => "bmp",
+        Some("image/svg+xml") => "svg",
+        Some("text/plain") => "txt",
+        Some(ct) => mime_guess::get_mime_extensions_str(ct)
+            .and_then(|exts| exts.first())
+            .copied()
+            .unwrap_or("bin"),
+        None => "bin",
+    }
+}
+
+/// Strip path separators and traversal from an attachment-supplied filename so
+/// it cannot escape the output directory.
+fn sanitize_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '\0' => '_',
+            other => other,
+        })
+        .collect();
+    let cleaned = cleaned.trim_start_matches(['.', ' ']).trim_end();
+    if cleaned.is_empty() {
+        "attachment.bin".to_string()
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// Avoid clobbering existing files by suffixing `-1`, `-2`, … before the extension.
+fn unique_path(candidate: PathBuf) -> PathBuf {
+    if !candidate.exists() {
+        return candidate;
+    }
+    let stem = candidate
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "attachment".to_string());
+    let ext = candidate
+        .extension()
+        .map(|e| format!(".{}", e.to_string_lossy()))
+        .unwrap_or_default();
+    let parent = candidate.parent().unwrap_or(Path::new("."));
+    (1..)
+        .map(|n| parent.join(format!("{stem}-{n}{ext}")))
+        .find(|p| !p.exists())
+        .expect("unbounded suffix search always terminates")
+}
+
+/// Write to `<path>.part` then rename, so a failed download never leaves a
+/// truncated file at the final path.
+fn write_atomically(target: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = target.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TeamsError::InvalidInput(format!(
+                    "Failed to create directory '{}': {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+    let part = target.with_extension(format!(
+        "{}part",
+        target
+            .extension()
+            .map(|e| format!("{}.", e.to_string_lossy()))
+            .unwrap_or_default()
+    ));
+    std::fs::write(&part, bytes).map_err(|e| {
+        TeamsError::InvalidInput(format!("Failed to write '{}': {e}", part.display()))
+    })?;
+    std::fs::rename(&part, target).map_err(|e| {
+        TeamsError::InvalidInput(format!("Failed to rename to '{}': {e}", target.display()))
+    })
+}
+
+fn augment_error(err: TeamsError, note: &str) -> TeamsError {
+    if note.is_empty() {
+        return err;
+    }
+    match err {
+        TeamsError::PermissionDenied(m) => TeamsError::PermissionDenied(format!("{m}{note}")),
+        TeamsError::NotFound(m) => TeamsError::NotFound(format!("{m}{note}")),
+        TeamsError::InvalidInput(m) => TeamsError::InvalidInput(format!("{m}{note}")),
+        TeamsError::ApiError { status, message } => TeamsError::ApiError {
+            status,
+            message: format!("{message}{note}"),
+        },
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_traversal_and_separators() {
+        assert_eq!(sanitize_filename("../../etc/passwd"), "_.._etc_passwd");
+        assert_eq!(sanitize_filename("a/b\\c:d"), "a_b_c_d");
+        assert_eq!(sanitize_filename("  .hidden"), "hidden");
+        assert_eq!(sanitize_filename(""), "attachment.bin");
+        assert_eq!(sanitize_filename("NetskopeLogs.zip"), "NetskopeLogs.zip");
+    }
+
+    #[test]
+    fn extension_covers_common_image_types() {
+        assert_eq!(extension_for(Some("image/png")), "png");
+        assert_eq!(extension_for(Some("image/jpeg")), "jpg");
+        assert_eq!(extension_for(None), "bin");
+        assert_eq!(extension_for(Some("application/x-unknown-thing")), "bin");
+    }
+
+    #[test]
+    fn unique_path_suffixes_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("shot.png");
+        std::fs::write(&first, b"x").unwrap();
+        let next = unique_path(first.clone());
+        assert_eq!(next, dir.path().join("shot-1.png"));
+        std::fs::write(&next, b"x").unwrap();
+        assert_eq!(unique_path(first), dir.path().join("shot-2.png"));
+    }
+
+    #[test]
+    fn write_atomically_leaves_no_part_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.png");
+        write_atomically(&target, b"bytes").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"bytes");
+        assert!(!dir.path().join("out.png.part").exists());
+    }
+
+    #[test]
+    fn code_snippet_id_extracted_from_graph_url_only() {
+        assert_eq!(
+            code_snippet_hosted_content_id(
+                "https://graph.microsoft.com/v1.0/chats/19:x/messages/m1/hostedContents/aWQ9/$value"
+            )
+            .as_deref(),
+            Some("aWQ9")
+        );
+        // Percent-encoded IDs are decoded so the rebuilt URL doesn't double-encode.
+        assert_eq!(
+            code_snippet_hosted_content_id(
+                "https://graph.microsoft.com/v1.0/chats/c/messages/m/hostedContents/aWQ%3D/$value"
+            )
+            .as_deref(),
+            Some("aWQ=")
+        );
+        // A URL pointing anywhere else must be rejected, not fetched.
+        assert_eq!(
+            code_snippet_hosted_content_id("https://evil.example.com/steal-token"),
+            None
+        );
+        assert_eq!(
+            code_snippet_hosted_content_id(
+                "https://evil.example.com/hostedContents/x/$value/extra"
+            ),
+            None
+        );
+        assert_eq!(
+            code_snippet_hosted_content_id("https://evil.example.com/hostedContents//$value"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_message_ref_validates_target_combinations() {
+        assert!(matches!(
+            resolve_message_ref(None, None, Some("19:x".into()), None, "m".into()),
+            Ok(MessageRef::Chat { .. })
+        ));
+        assert!(matches!(
+            resolve_message_ref(
+                Some("t".into()),
+                Some("c".into()),
+                None,
+                Some("r".into()),
+                "m".into()
+            ),
+            Ok(MessageRef::ChannelReply { .. })
+        ));
+        assert!(resolve_message_ref(Some("t".into()), None, None, None, "m".into()).is_err());
+        assert!(resolve_message_ref(
+            None,
+            None,
+            Some("19:x".into()),
+            Some("r".into()),
+            "m".into()
+        )
+        .is_err());
+    }
+}

--- a/src/cli/message_attachments.rs
+++ b/src/cli/message_attachments.rs
@@ -303,8 +303,13 @@ async fn fetch_item_bytes(
 /// is taken, percent-decoded, and the request URL is rebuilt from the message
 /// reference we already resolved.
 fn code_snippet_hosted_content_id(url: &str) -> Option<String> {
-    let path = url.split(['?', '#']).next().unwrap_or(url);
-    let mut segments = path.split('/').skip_while(|s| *s != "hostedContents");
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("graph.microsoft.com") {
+        return None;
+    }
+    let mut segments = parsed
+        .path_segments()?
+        .skip_while(|s| *s != "hostedContents");
     segments.next()?;
     let id = segments.next().filter(|s| !s.is_empty())?;
     if segments.next() != Some("$value") || segments.next().is_some() {
@@ -423,13 +428,10 @@ fn write_atomically(target: &Path, bytes: &[u8]) -> Result<()> {
             })?;
         }
     }
-    let part = target.with_extension(format!(
-        "{}part",
-        target
-            .extension()
-            .map(|e| format!("{}.", e.to_string_lossy()))
-            .unwrap_or_default()
-    ));
+    let filename = target
+        .file_name()
+        .ok_or_else(|| TeamsError::InvalidInput("Target path has no filename".into()))?;
+    let part = target.with_file_name(format!("{}.part", filename.to_string_lossy()));
     std::fs::write(&part, bytes).map_err(|e| {
         TeamsError::InvalidInput(format!("Failed to write '{}': {e}", part.display()))
     })?;
@@ -493,6 +495,11 @@ mod tests {
         write_atomically(&target, b"bytes").unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"bytes");
         assert!(!dir.path().join("out.png.part").exists());
+
+        let no_extension = dir.path().join("out");
+        write_atomically(&no_extension, b"more").unwrap();
+        assert_eq!(std::fs::read(&no_extension).unwrap(), b"more");
+        assert!(!dir.path().join("out.part").exists());
     }
 
     #[test]
@@ -515,6 +522,10 @@ mod tests {
         // A URL pointing anywhere else must be rejected, not fetched.
         assert_eq!(
             code_snippet_hosted_content_id("https://evil.example.com/steal-token"),
+            None
+        );
+        assert_eq!(
+            code_snippet_hosted_content_id("https://evil.example.com/hostedContents/x/$value"),
             None
         );
         assert_eq!(

--- a/src/cli/message_media.rs
+++ b/src/cli/message_media.rs
@@ -18,13 +18,14 @@ pub enum AttachDestination<'a> {
 }
 
 /// Per-image cap: hosted contents ride a single JSON request with a 4MB Graph
-/// limit, and base64 inflates payloads by a third.
-const MAX_INLINE_IMAGE_SIZE: usize = 3 * 1024 * 1024;
+/// limit, and base64 inflates payloads by a third. Use decimal 3 MB so the
+/// encoded image plus JSON wrapper stays below 4 MiB.
+const MAX_INLINE_IMAGE_SIZE: usize = 3_000_000;
 
 /// Aggregate cap across all `--image` files: every image's base64 string is
 /// embedded in the same message-create body, so the encoded total — not just
 /// each file — must fit Graph's 4MB request limit.
-const MAX_INLINE_TOTAL_ENCODED: usize = 4 * 1024 * 1024;
+const MAX_INLINE_TOTAL_ENCODED: usize = 4_000_000;
 
 /// Extend a send request with inline images (`--image`, write-side hosted
 /// contents) and file attachments (`--attach`, drive upload + reference).

--- a/src/cli/message_media.rs
+++ b/src/cli/message_media.rs
@@ -1,0 +1,348 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+
+use crate::api::{self, GraphClient};
+use crate::error::{Result, TeamsError};
+use crate::models::message::{ChatMessageAttachment, HostedContentUpload, SendMessageRequest};
+
+/// Where `--attach` files get uploaded before the message references them.
+/// Chats use the sender's own OneDrive; channels use the team's SharePoint
+/// library — which is why the two need different Files scopes (see
+/// docs/attachments-spec.md).
+pub enum AttachDestination<'a> {
+    Chat,
+    Channel {
+        team_id: &'a str,
+        channel_id: &'a str,
+    },
+}
+
+/// Per-image cap: hosted contents ride a single JSON request with a 4MB Graph
+/// limit, and base64 inflates payloads by a third.
+const MAX_INLINE_IMAGE_SIZE: usize = 3 * 1024 * 1024;
+
+/// Aggregate cap across all `--image` files: every image's base64 string is
+/// embedded in the same message-create body, so the encoded total — not just
+/// each file — must fit Graph's 4MB request limit.
+const MAX_INLINE_TOTAL_ENCODED: usize = 4 * 1024 * 1024;
+
+/// Extend a send request with inline images (`--image`, write-side hosted
+/// contents) and file attachments (`--attach`, drive upload + reference).
+pub async fn apply_media(
+    client: &GraphClient,
+    req: &mut SendMessageRequest,
+    images: &[String],
+    attaches: &[String],
+    dest: AttachDestination<'_>,
+) -> Result<()> {
+    if images.is_empty() && attaches.is_empty() {
+        return Ok(());
+    }
+
+    ensure_html_body(req);
+    let mut body = req.body.content.take().unwrap_or_default();
+    let mut attachments = req.attachments.take().unwrap_or_default();
+
+    let (images_html, hosted) = inline_images(images)?;
+    body.push_str(&images_html);
+
+    for path in attaches {
+        let (bytes, content_type, filename) = read_attachment(path)?;
+        let item = match dest {
+            AttachDestination::Chat => {
+                api::files::upload_chat_attachment(client, &filename, bytes, &content_type).await?
+            }
+            AttachDestination::Channel {
+                team_id,
+                channel_id,
+            } => {
+                api::files::upload_channel_attachment(
+                    client,
+                    team_id,
+                    channel_id,
+                    &filename,
+                    bytes,
+                    &content_type,
+                )
+                .await?
+            }
+        };
+        let attachment = reference_attachment(&item)?;
+        body.push_str(&attachment_tag(
+            attachment.id.as_deref().unwrap_or_default(),
+        ));
+        attachments.push(attachment);
+    }
+
+    req.body.content = Some(body);
+    if !hosted.is_empty() {
+        req.hosted_contents = Some(hosted);
+    }
+    if !attachments.is_empty() {
+        req.attachments = Some(attachments);
+    }
+    Ok(())
+}
+
+/// Build the body-HTML fragment and hosted-content uploads for `--image`
+/// files. Temporary IDs are 1-based to match Graph's documented examples.
+fn inline_images(images: &[String]) -> Result<(String, Vec<HostedContentUpload>)> {
+    let mut html = String::new();
+    let mut hosted = Vec::new();
+    let mut total_encoded = 0usize;
+    for (i, path) in images.iter().enumerate() {
+        let temporary_id = (i + 1).to_string();
+        let (bytes, content_type) = read_image(path)?;
+        let content_bytes = BASE64.encode(&bytes);
+        total_encoded += content_bytes.len();
+        if total_encoded > MAX_INLINE_TOTAL_ENCODED {
+            return Err(TeamsError::InvalidInput(format!(
+                "--image files together are {total_encoded} bytes base64-encoded, exceeding \
+                 the 4MB limit on the single message create request they all ride in. \
+                 Send some of them with --attach instead."
+            )));
+        }
+        html.push_str(&img_html(&temporary_id));
+        hosted.push(HostedContentUpload {
+            temporary_id,
+            content_bytes,
+            content_type,
+        });
+    }
+    Ok((html, hosted))
+}
+
+/// Media requires an HTML body; escape and wrap a plain-text one.
+fn ensure_html_body(req: &mut SendMessageRequest) {
+    if req.body.content_type.as_deref() == Some("html") {
+        return;
+    }
+    let text = req.body.content.take().unwrap_or_default();
+    req.body.content = Some(if text.is_empty() {
+        String::new()
+    } else {
+        format!("<p>{}</p>", escape_html(&text))
+    });
+    req.body.content_type = Some("html".to_string());
+}
+
+fn escape_html(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\n', "<br>")
+}
+
+fn img_html(temporary_id: &str) -> String {
+    format!(r#"<p><img src="../hostedContents/{temporary_id}/$value"></p>"#)
+}
+
+fn attachment_tag(attachment_id: &str) -> String {
+    format!(r#"<attachment id="{attachment_id}"></attachment>"#)
+}
+
+/// The message attachment `id` must be the GUID inside the driveItem's eTag,
+/// e.g. `"{5FF69C5F-7CCD-47A2-879C-1A506F961DBC},2"` → the bare GUID.
+fn etag_guid(e_tag: &str) -> Option<String> {
+    let start = e_tag.find('{')? + 1;
+    let end = e_tag.find('}')?;
+    let guid = e_tag.get(start..end)?;
+    if guid.is_empty() {
+        return None;
+    }
+    Some(guid.to_string())
+}
+
+fn reference_attachment(item: &crate::models::file::DriveItem) -> Result<ChatMessageAttachment> {
+    let guid = item
+        .e_tag
+        .as_deref()
+        .and_then(etag_guid)
+        .ok_or_else(|| TeamsError::ApiError {
+            status: 0,
+            message: "Upload succeeded but the driveItem has no eTag GUID to reference".into(),
+        })?;
+    let content_url = item.web_url.clone().ok_or_else(|| TeamsError::ApiError {
+        status: 0,
+        message: "Upload succeeded but the driveItem has no webUrl".into(),
+    })?;
+    Ok(ChatMessageAttachment {
+        id: Some(guid),
+        content_type: Some("reference".to_string()),
+        content: None,
+        content_url: Some(content_url),
+        name: item.name.clone(),
+        thumbnail_url: None,
+        teams_app_id: None,
+    })
+}
+
+fn read_image(path: &str) -> Result<(Vec<u8>, String)> {
+    let bytes = read_file(path)?;
+    if bytes.len() > MAX_INLINE_IMAGE_SIZE {
+        return Err(TeamsError::InvalidInput(format!(
+            "--image '{path}' is {} bytes; inline images are capped at 3MB because they \
+             ride the message create request (Graph's 4MB limit, minus base64 overhead). \
+             Send it with --attach instead.",
+            bytes.len()
+        )));
+    }
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    if mime.type_() != mime_guess::mime::IMAGE {
+        return Err(TeamsError::InvalidInput(format!(
+            "--image '{path}' does not look like an image (guessed type: {mime}); \
+             use --attach for non-image files."
+        )));
+    }
+    Ok((bytes, mime.essence_str().to_string()))
+}
+
+fn read_attachment(path: &str) -> Result<(Vec<u8>, String, String)> {
+    let bytes = read_file(path)?;
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    let filename = std::path::Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|n| !n.is_empty())
+        .ok_or_else(|| {
+            TeamsError::InvalidInput(format!("--attach '{path}' has no usable filename"))
+        })?;
+    Ok((bytes, mime.essence_str().to_string(), filename))
+}
+
+fn read_file(path: &str) -> Result<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|e| TeamsError::InvalidInput(format!("Failed to read '{path}': {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::message::ItemBody;
+
+    fn text_request(body: &str) -> SendMessageRequest {
+        SendMessageRequest {
+            body: ItemBody {
+                content_type: Some("text".into()),
+                content: Some(body.into()),
+            },
+            attachments: None,
+            hosted_contents: None,
+        }
+    }
+
+    #[test]
+    fn etag_guid_extracts_bare_guid() {
+        assert_eq!(
+            etag_guid("\"{5FF69C5F-7CCD-47A2-879C-1A506F961DBC},2\"").as_deref(),
+            Some("5FF69C5F-7CCD-47A2-879C-1A506F961DBC")
+        );
+        assert_eq!(etag_guid("no-braces"), None);
+        assert_eq!(etag_guid("{}"), None);
+    }
+
+    #[test]
+    fn plain_text_body_is_escaped_and_wrapped_for_media() {
+        let mut req = text_request("a <b> & \"c\"\nnext");
+        ensure_html_body(&mut req);
+        assert_eq!(req.body.content_type.as_deref(), Some("html"));
+        assert_eq!(
+            req.body.content.as_deref(),
+            Some("<p>a &lt;b&gt; &amp; &quot;c&quot;<br>next</p>")
+        );
+    }
+
+    #[test]
+    fn html_body_is_left_alone() {
+        let mut req = text_request("<p>already html</p>");
+        req.body.content_type = Some("html".into());
+        ensure_html_body(&mut req);
+        assert_eq!(req.body.content.as_deref(), Some("<p>already html</p>"));
+    }
+
+    #[test]
+    fn img_and_attachment_html_shapes() {
+        assert_eq!(
+            img_html("1"),
+            r#"<p><img src="../hostedContents/1/$value"></p>"#
+        );
+        assert_eq!(
+            attachment_tag("ABC-123"),
+            r#"<attachment id="ABC-123"></attachment>"#
+        );
+    }
+
+    #[test]
+    fn read_image_rejects_non_images_and_oversize() {
+        let dir = tempfile::tempdir().unwrap();
+        let txt = dir.path().join("notes.txt");
+        std::fs::write(&txt, b"hello").unwrap();
+        let err = read_image(txt.to_str().unwrap()).unwrap_err();
+        assert!(err.to_string().contains("--attach"), "got: {err}");
+
+        let big = dir.path().join("big.png");
+        std::fs::write(&big, vec![0u8; MAX_INLINE_IMAGE_SIZE + 1]).unwrap();
+        let err = read_image(big.to_str().unwrap()).unwrap_err();
+        assert!(err.to_string().contains("capped at 3MB"), "got: {err}");
+    }
+
+    #[test]
+    fn inline_images_builds_html_and_base64_hosted_contents() {
+        // Minimal valid PNG header bytes; content doesn't matter for assembly.
+        let dir = tempfile::tempdir().unwrap();
+        let png = dir.path().join("shot.png");
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\n").unwrap();
+
+        let (html, hosted) = inline_images(&[png.to_string_lossy().into_owned()]).unwrap();
+        assert_eq!(html, r#"<p><img src="../hostedContents/1/$value"></p>"#);
+        assert_eq!(hosted.len(), 1);
+        assert_eq!(hosted[0].temporary_id, "1");
+        assert_eq!(hosted[0].content_type, "image/png");
+        assert_eq!(
+            BASE64.decode(&hosted[0].content_bytes).unwrap(),
+            b"\x89PNG\r\n\x1a\n"
+        );
+    }
+
+    #[test]
+    fn inline_images_rejects_aggregate_over_request_limit() {
+        // Each file passes the 3MB per-image cap, but their combined base64
+        // payload exceeds the 4MB request limit.
+        let dir = tempfile::tempdir().unwrap();
+        let mut paths = Vec::new();
+        for name in ["a.png", "b.png"] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, vec![0u8; 2 * 1024 * 1024]).unwrap();
+            paths.push(path.to_string_lossy().into_owned());
+        }
+        let err = inline_images(&paths).unwrap_err();
+        assert!(err.to_string().contains("together"), "got: {err}");
+    }
+
+    #[test]
+    fn reference_attachment_requires_etag_and_weburl() {
+        let mut item = crate::models::file::DriveItem {
+            id: Some("i".into()),
+            name: Some("NetskopeLogs.zip".into()),
+            size: None,
+            web_url: Some("https://x.sharepoint.com/f.zip".into()),
+            e_tag: Some("\"{ABC-DEF},1\"".into()),
+            created_date_time: None,
+            last_modified_date_time: None,
+            created_by: None,
+            last_modified_by: None,
+            file: None,
+            folder: None,
+            download_url: None,
+            parent_reference: None,
+        };
+        let att = reference_attachment(&item).unwrap();
+        assert_eq!(att.id.as_deref(), Some("ABC-DEF"));
+        assert_eq!(att.content_type.as_deref(), Some("reference"));
+        assert_eq!(att.name.as_deref(), Some("NetskopeLogs.zip"));
+
+        item.e_tag = None;
+        assert!(reference_attachment(&item).is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,10 +19,11 @@ pub mod team;
 pub mod user;
 
 use clap::{Parser, Subcommand};
+use std::io::Write as _;
 
 use crate::api::PaginationOpts;
 use crate::config::ConfigFile;
-use crate::error::Result;
+use crate::error::{Result, TeamsError};
 use crate::output::OutputFormat;
 
 #[derive(Debug, Parser)]
@@ -193,11 +194,7 @@ pub async fn run(cli: Cli, config: &ConfigFile) -> Result<()> {
         Commands::Config { command } => {
             config_cmd::run(command, config, cli.config.as_deref(), format).await
         }
-        Commands::Completions { shell } => {
-            use clap::CommandFactory;
-            clap_complete::generate(shell, &mut Cli::command(), "teams", &mut std::io::stdout());
-            Ok(())
-        }
+        Commands::Completions { shell } => generate_completions(shell),
         Commands::Team { command } => {
             team::run(command, &runtime_config, &profile, format, &pagination).await
         }
@@ -239,4 +236,29 @@ pub async fn run(cli: Cli, config: &ConfigFile) -> Result<()> {
         }
         Commands::Listen { port } => listen::run(port).await,
     }
+}
+
+fn generate_completions(shell: clap_complete::Shell) -> Result<()> {
+    let output = std::thread::Builder::new()
+        .name("teams-completions".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            use clap::CommandFactory;
+
+            let mut command = Cli::command();
+            let mut output = Vec::new();
+            clap_complete::generate(shell, &mut command, "teams", &mut output);
+            output
+        })
+        .map_err(|e| {
+            TeamsError::Other(anyhow::anyhow!("Failed to start completion generator: {e}"))
+        })?
+        .join()
+        .map_err(|_| TeamsError::Other(anyhow::anyhow!("Completion generator panicked")))?;
+
+    std::io::stdout().write_all(&output).map_err(|e| {
+        TeamsError::Other(anyhow::anyhow!(
+            "Failed to write completions to stdout: {e}"
+        ))
+    })
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod listen;
 pub mod meeting;
 pub mod message;
 pub mod message_attachments;
+pub mod message_media;
 pub mod notification;
 pub mod presence;
 pub mod search;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod file;
 pub mod listen;
 pub mod meeting;
 pub mod message;
+pub mod message_attachments;
 pub mod notification;
 pub mod presence;
 pub mod search;

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -22,6 +22,16 @@ pub enum UserCommand {
         #[arg(long)]
         filter: Option<String>,
     },
+    /// Resolve a name or email to user candidates, degrading with available
+    /// scopes: exact lookup, then people search, then a roster sweep over
+    /// shared group/meeting chats
+    Resolve {
+        /// Display name, email address, UPN, or user object ID
+        query: String,
+        /// Maximum group/meeting chats to scan in the roster-sweep fallback
+        #[arg(long, default_value_t = 200)]
+        max_chats: u64,
+    },
 }
 
 pub async fn run(
@@ -72,6 +82,55 @@ pub async fn run(
                 output::table::print_table(headers, rows);
             } else {
                 output::print_success_list(format, &users, start);
+            }
+            Ok(())
+        }
+
+        UserCommand::Resolve { query, max_chats } => {
+            let start = Instant::now();
+            let result = api::resolve::resolve_user(&client, &query, max_chats).await?;
+
+            if result.candidates.is_empty() {
+                let attempted: Vec<String> = result
+                    .stages
+                    .iter()
+                    .map(|s| format!("{}={}", s.stage, s.status))
+                    .collect();
+                return Err(crate::error::TeamsError::NotFound(format!(
+                    "no user matching '{}' ({})",
+                    query,
+                    attempted.join(", ")
+                )));
+            }
+
+            if format == OutputFormat::Human {
+                let headers = vec![
+                    "ID",
+                    "Display Name",
+                    "Email",
+                    "UPN",
+                    "Job Title",
+                    "Department",
+                    "Via",
+                ];
+                let rows: Vec<Vec<String>> = result
+                    .candidates
+                    .iter()
+                    .map(|c| {
+                        vec![
+                            c.id.clone().unwrap_or_default(),
+                            c.display_name.clone().unwrap_or_default(),
+                            c.mail.clone().unwrap_or_default(),
+                            c.user_principal_name.clone().unwrap_or_default(),
+                            c.job_title.clone().unwrap_or_default(),
+                            c.department.clone().unwrap_or_default(),
+                            c.via.clone(),
+                        ]
+                    })
+                    .collect();
+                output::table::print_table(headers, rows);
+            } else {
+                output::print_success(format, &result, start);
             }
             Ok(())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,15 +251,17 @@ pub fn ensure_offline_access(scopes: &str) -> String {
     }
 }
 
-/// Resolve the delegated scope string: CLI flag or `TEAMS_CLI_SCOPES` env var
-/// (delivered via clap), then the profile's `scopes`, then the defaults.
-/// Blank values fall through so an empty env var cannot produce an empty
-/// OAuth scope request. Overrides always get `offline_access` appended.
-pub fn resolve_delegated_scopes(
+/// Resolve an explicitly configured delegated scope override: CLI flag or
+/// `TEAMS_CLI_SCOPES` env var (delivered via clap), then the profile's
+/// `scopes`. Returns `None` when neither is set so callers can pick their own
+/// fallback — login falls back to the defaults, refresh to the stored token's
+/// scope. Blank values fall through so an empty env var cannot produce an
+/// empty OAuth scope request. Overrides always get `offline_access` appended.
+pub fn resolve_delegated_scopes_override(
     scopes_arg: Option<&str>,
     profile: &str,
     config: &ConfigFile,
-) -> String {
+) -> Option<String> {
     let non_blank = |s: &str| {
         let trimmed = s.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
@@ -275,6 +277,16 @@ pub fn resolve_delegated_scopes(
                 .and_then(non_blank)
         })
         .map(|scopes| ensure_offline_access(&scopes))
+}
+
+/// Resolve the delegated scope string for login: the explicit override when
+/// set, otherwise the default delegated scopes.
+pub fn resolve_delegated_scopes(
+    scopes_arg: Option<&str>,
+    profile: &str,
+    config: &ConfigFile,
+) -> String {
+    resolve_delegated_scopes_override(scopes_arg, profile, config)
         .unwrap_or_else(|| DEFAULT_DELEGATED_SCOPES.to_string())
 }
 
@@ -476,6 +488,24 @@ scopes = "User.Read People.Read offline_access"
         assert_eq!(
             resolve_delegated_scopes(None, "default", &config),
             DEFAULT_DELEGATED_SCOPES
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_override_none_when_unset() {
+        let config = ConfigFile::default();
+        assert_eq!(
+            resolve_delegated_scopes_override(None, "default", &config),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_override_some_for_profile_value() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes_override(None, "work", &config).as_deref(),
+            Some("User.Read People.Read offline_access")
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ pub struct ProfileConfig {
     pub client_id: Option<String>,
     pub tenant_id: Option<String>,
     pub auth_flow: Option<String>,
+    pub scopes: Option<String>,
 }
 
 fn default_format() -> String {
@@ -239,6 +240,44 @@ pub fn resolve_delegated_tenant_id(
         .unwrap_or_else(|| DEFAULT_DELEGATED_TENANT_ID.to_string())
 }
 
+/// Append `offline_access` to a delegated scope string when it is missing, so
+/// the identity platform always issues a refresh token.
+pub fn ensure_offline_access(scopes: &str) -> String {
+    let trimmed = scopes.trim();
+    if trimmed.split_whitespace().any(|s| s == "offline_access") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed} offline_access")
+    }
+}
+
+/// Resolve the delegated scope string: CLI flag or `TEAMS_CLI_SCOPES` env var
+/// (delivered via clap), then the profile's `scopes`, then the defaults.
+/// Blank values fall through so an empty env var cannot produce an empty
+/// OAuth scope request. Overrides always get `offline_access` appended.
+pub fn resolve_delegated_scopes(
+    scopes_arg: Option<&str>,
+    profile: &str,
+    config: &ConfigFile,
+) -> String {
+    let non_blank = |s: &str| {
+        let trimmed = s.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
+
+    scopes_arg
+        .and_then(non_blank)
+        .or_else(|| {
+            config
+                .profiles
+                .get(profile)
+                .and_then(|p| p.scopes.as_deref())
+                .and_then(non_blank)
+        })
+        .map(|scopes| ensure_offline_access(&scopes))
+        .unwrap_or_else(|| DEFAULT_DELEGATED_SCOPES.to_string())
+}
+
 pub fn resolve_client_secret(cli_flag: Option<&str>) -> Option<String> {
     if let Some(v) = cli_flag {
         return Some(v.to_string());
@@ -321,6 +360,7 @@ max_retries = 5
 client_id = "abc-123"
 tenant_id = "tenant-456"
 auth_flow = "device-code"
+scopes = "User.Read People.Read offline_access"
 "#;
         let config: ConfigFile = toml::from_str(toml_str).unwrap();
         assert_eq!(config.default.profile.as_deref(), Some("work"));
@@ -334,6 +374,10 @@ auth_flow = "device-code"
         assert_eq!(work.client_id.as_deref(), Some("abc-123"));
         assert_eq!(work.tenant_id.as_deref(), Some("tenant-456"));
         assert_eq!(work.auth_flow.as_deref(), Some("device-code"));
+        assert_eq!(
+            work.scopes.as_deref(),
+            Some("User.Read People.Read offline_access")
+        );
     }
 
     #[test]
@@ -373,6 +417,7 @@ auth_flow = "device-code"
                 client_id: Some("from-config".into()),
                 tenant_id: None,
                 auth_flow: None,
+                scopes: None,
             },
         );
 
@@ -413,6 +458,69 @@ auth_flow = "device-code"
         assert!(!DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Read.All"));
     }
 
+    fn config_with_profile_scopes(scopes: Option<&str>) -> ConfigFile {
+        let mut config = ConfigFile::default();
+        config.profiles.insert(
+            "work".into(),
+            ProfileConfig {
+                scopes: scopes.map(|s| s.to_string()),
+                ..ProfileConfig::default()
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_defaults_when_unset() {
+        let config = ConfigFile::default();
+        assert_eq!(
+            resolve_delegated_scopes(None, "default", &config),
+            DEFAULT_DELEGATED_SCOPES
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_uses_profile_and_appends_offline_access() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(None, "work", &config),
+            "User.Read People.Read offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_preserves_existing_offline_access() {
+        let config = config_with_profile_scopes(Some("User.Read offline_access People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(None, "work", &config),
+            "User.Read offline_access People.Read"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_cli_value_beats_profile() {
+        let config = config_with_profile_scopes(Some("User.Read People.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(Some("Chat.ReadWrite"), "work", &config),
+            "Chat.ReadWrite offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_delegated_scopes_blank_values_fall_through() {
+        let blank_profile = config_with_profile_scopes(Some("   "));
+        assert_eq!(
+            resolve_delegated_scopes(Some("  "), "work", &blank_profile),
+            DEFAULT_DELEGATED_SCOPES
+        );
+
+        let config = config_with_profile_scopes(Some("User.Read"));
+        assert_eq!(
+            resolve_delegated_scopes(Some(""), "work", &config),
+            "User.Read offline_access"
+        );
+    }
+
     #[test]
     fn delegated_auth_byo_requires_client_id() {
         let mut config = ConfigFile::default();
@@ -423,6 +531,7 @@ auth_flow = "device-code"
                 client_id: None,
                 tenant_id: Some("tenant".into()),
                 auth_flow: Some("device-code".into()),
+                scopes: None,
             },
         );
 

--- a/src/models/attachment_inventory.rs
+++ b/src/models/attachment_inventory.rs
@@ -1,0 +1,402 @@
+use serde::Serialize;
+
+use crate::models::message::{ChatMessage, ChatMessageHostedContent};
+
+/// What a downloadable (or at least enumerable) piece of message content is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemKind {
+    /// Inline media pasted into the message (screenshots, GIFs).
+    HostedContent,
+    /// File attached via SharePoint/OneDrive (`contentType: "reference"`).
+    FileReference,
+    /// Code block; its body is a hosted content behind `codeSnippetUrl`.
+    CodeSnippet,
+    /// Adaptive/hero/connector card; JSON is inline in the message.
+    Card,
+    /// Quoted or forwarded message context; inline in the message.
+    MessageReference,
+    /// Unrecognized attachment content type.
+    Other,
+}
+
+impl ItemKind {
+    pub fn downloadable(self) -> bool {
+        matches!(
+            self,
+            Self::HostedContent | Self::FileReference | Self::CodeSnippet
+        )
+    }
+}
+
+/// One entry in the unified inventory of a message's attachments and inline
+/// images, indexed stably so callers can request downloads by number.
+#[derive(Debug, Clone, Serialize)]
+pub struct AttachmentItem {
+    pub index: usize,
+    pub kind: ItemKind,
+    pub downloadable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hosted_content_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_snippet_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<String>,
+}
+
+impl AttachmentItem {
+    fn new(index: usize, kind: ItemKind) -> Self {
+        Self {
+            index,
+            kind,
+            downloadable: kind.downloadable(),
+            hosted_content_id: None,
+            attachment_id: None,
+            name: None,
+            content_type: None,
+            content_url: None,
+            code_snippet_url: None,
+            language: None,
+            alt: None,
+            width: None,
+            height: None,
+        }
+    }
+}
+
+/// Build the unified inventory for a message from its body HTML, the
+/// hostedContents collection, and the attachments array.
+///
+/// The body HTML is the source of truth for inline-image order and display
+/// metadata; the hostedContents collection is authoritative for existence
+/// (its `contentBytes` are always null, so bytes come later via `/$value`).
+/// Hosted contents referenced by a code-snippet attachment's `codeSnippetUrl`
+/// are folded into that snippet's entry rather than listed twice.
+pub fn build_inventory(
+    message: &ChatMessage,
+    hosted: &[ChatMessageHostedContent],
+) -> Vec<AttachmentItem> {
+    let body_html = message
+        .body
+        .as_ref()
+        .and_then(|b| b.content.as_deref())
+        .unwrap_or_default();
+    let body_images = hosted_images_in_body(body_html);
+
+    let snippet_hosted_ids: Vec<String> = message
+        .attachments
+        .iter()
+        .flatten()
+        .filter_map(|a| {
+            let content = a.content.as_deref()?;
+            let url = code_snippet_url(content)?;
+            hosted_content_id_from_url(&url)
+        })
+        .collect();
+
+    let mut items = Vec::new();
+
+    // Inline images first, in body order, joined to the authoritative list.
+    for img in &body_images {
+        if snippet_hosted_ids.contains(&img.hosted_content_id) {
+            continue;
+        }
+        let mut item = AttachmentItem::new(items.len(), ItemKind::HostedContent);
+        item.hosted_content_id = Some(img.hosted_content_id.clone());
+        item.alt = img.alt.clone();
+        item.width = img.width.clone();
+        item.height = img.height.clone();
+        items.push(item);
+    }
+
+    // Hosted contents not visible in the body (defensive; rare in practice).
+    for hc in hosted {
+        let Some(id) = hc.id.as_deref() else { continue };
+        if snippet_hosted_ids.iter().any(|s| s == id)
+            || body_images.iter().any(|i| i.hosted_content_id == id)
+        {
+            continue;
+        }
+        let mut item = AttachmentItem::new(items.len(), ItemKind::HostedContent);
+        item.hosted_content_id = Some(id.to_string());
+        item.content_type = hc.content_type.clone();
+        items.push(item);
+    }
+
+    for att in message.attachments.iter().flatten() {
+        let kind = match att.content_type.as_deref() {
+            Some("reference") => ItemKind::FileReference,
+            Some("application/vnd.microsoft.card.codesnippet") => ItemKind::CodeSnippet,
+            Some(t) if t.starts_with("application/vnd.microsoft.card.") => ItemKind::Card,
+            Some("messageReference") | Some("forwardedMessageReference") => {
+                ItemKind::MessageReference
+            }
+            _ => ItemKind::Other,
+        };
+        let mut item = AttachmentItem::new(items.len(), kind);
+        item.attachment_id = att.id.clone();
+        item.name = att.name.clone();
+        item.content_type = att.content_type.clone();
+        item.content_url = att.content_url.clone();
+        if kind == ItemKind::CodeSnippet {
+            if let Some(content) = att.content.as_deref() {
+                item.code_snippet_url = code_snippet_url(content);
+                item.language = snippet_language(content);
+            }
+        }
+        items.push(item);
+    }
+
+    items
+}
+
+struct BodyImage {
+    hosted_content_id: String,
+    alt: Option<String>,
+    width: Option<String>,
+    height: Option<String>,
+}
+
+/// Extract hosted-content `<img>` references from message body HTML, in
+/// document order. Only images whose src is a Graph hostedContents `$value`
+/// URL are returned; external or data-URI images are not hosted contents.
+fn hosted_images_in_body(html: &str) -> Vec<BodyImage> {
+    let mut images = Vec::new();
+    let mut rest = html;
+    while let Some(pos) = rest.find("<img") {
+        rest = &rest[pos..];
+        let end = match rest.find('>') {
+            Some(e) => e,
+            None => break,
+        };
+        let tag = &rest[..end];
+        rest = &rest[end..];
+
+        let Some(src) = attr_value(tag, "src") else {
+            continue;
+        };
+        let Some(id) = hosted_content_id_from_url(&src) else {
+            continue;
+        };
+        images.push(BodyImage {
+            hosted_content_id: id,
+            alt: attr_value(tag, "alt"),
+            width: attr_value(tag, "width"),
+            height: attr_value(tag, "height"),
+        });
+    }
+    images
+}
+
+/// Pull the hosted-content ID out of a Graph `.../hostedContents/{id}/$value`
+/// URL, percent-decoding it back to the raw base64 form used by the API.
+fn hosted_content_id_from_url(url: &str) -> Option<String> {
+    if !url.contains("graph.microsoft.com/") {
+        return None;
+    }
+    let after = url.rsplit_once("/hostedContents/")?.1;
+    let id = after.strip_suffix("/$value")?;
+    if id.is_empty() {
+        return None;
+    }
+    Some(
+        urlencoding::decode(id)
+            .map(|c| c.into_owned())
+            .unwrap_or_else(|_| id.to_string()),
+    )
+}
+
+/// Read a double-quoted HTML attribute value from a single tag's text.
+fn attr_value(tag: &str, name: &str) -> Option<String> {
+    let needle = format!("{name}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn code_snippet_url(content_json: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(content_json).ok()?;
+    value
+        .get("codeSnippetUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+fn snippet_language(content_json: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(content_json).ok()?;
+    value
+        .get("language")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::message::{ChatMessageAttachment, ItemBody};
+
+    fn message_with(body_html: &str, attachments: Vec<ChatMessageAttachment>) -> ChatMessage {
+        ChatMessage {
+            id: Some("1783503421261".into()),
+            created_date_time: None,
+            from: None,
+            body: Some(ItemBody {
+                content_type: Some("html".into()),
+                content: Some(body_html.into()),
+            }),
+            attachments: Some(attachments),
+            message_type: Some("message".into()),
+        }
+    }
+
+    fn hosted(id: &str) -> ChatMessageHostedContent {
+        ChatMessageHostedContent {
+            id: Some(id.into()),
+            content_bytes: None,
+            content_type: None,
+        }
+    }
+
+    // Captured from a live channel message containing a pasted screenshot.
+    const REAL_BODY: &str = r#"<p>Hey, it says on Conductor one I have access to design drive but I still can't get in. Task #64674</p>
+<p><img src="https://graph.microsoft.com/v1.0/teams/5c42feaf-58be-42d3-9040-f35698cfdb0f/channels/19:b8fe94da69f446f38066d16443895c91@thread.skype/messages/1783503421261/hostedContents/aWQ9eF8wLWZyY2EtZDE0LTJhMjE5ODZiZTFkOTNhZGI3ZGE2YjA4ZTE3YmViODM3LHR5cGU9MSx1cmw9aHR0cHM6Ly9ldS1hcGkuYXNtLnNreXBlLmNvbS92MS9vYmplY3RzLzAtZnJjYS1kMTQtMmEyMTk4NmJlMWQ5M2FkYjdkYTZiMDhlMTdiZWI4Mzcvdmlld3MvaW1nbw==/$value" width="410" height="204" alt="image" itemid="0-frca-d14-2a21986be1d93adb7da6b08e17beb837"></p>"#;
+
+    const REAL_HOSTED_ID: &str = "aWQ9eF8wLWZyY2EtZDE0LTJhMjE5ODZiZTFkOTNhZGI3ZGE2YjA4ZTE3YmViODM3LHR5cGU9MSx1cmw9aHR0cHM6Ly9ldS1hcGkuYXNtLnNreXBlLmNvbS92MS9vYmplY3RzLzAtZnJjYS1kMTQtMmEyMTk4NmJlMWQ5M2FkYjdkYTZiMDhlMTdiZWI4Mzcvdmlld3MvaW1nbw==";
+
+    #[test]
+    fn inline_screenshot_is_inventoried_from_real_payload() {
+        let msg = message_with(REAL_BODY, vec![]);
+        let items = build_inventory(&msg, &[hosted(REAL_HOSTED_ID)]);
+        assert_eq!(items.len(), 1);
+        let item = &items[0];
+        assert_eq!(item.kind, ItemKind::HostedContent);
+        assert!(item.downloadable);
+        assert_eq!(item.hosted_content_id.as_deref(), Some(REAL_HOSTED_ID));
+        assert_eq!(item.alt.as_deref(), Some("image"));
+        assert_eq!(item.width.as_deref(), Some("410"));
+        assert_eq!(item.height.as_deref(), Some("204"));
+    }
+
+    #[test]
+    fn file_reference_attachment_is_inventoried() {
+        let att = ChatMessageAttachment {
+            id: Some("C0F75B79".into()),
+            content_type: Some("reference".into()),
+            content: None,
+            content_url: Some(
+                "https://tenant-my.sharepoint.com/personal/u/Documents/NetskopeLogs.zip".into(),
+            ),
+            name: Some("NetskopeLogs.zip".into()),
+            thumbnail_url: None,
+            teams_app_id: None,
+        };
+        let msg = message_with("<p>logs attached</p>", vec![att]);
+        let items = build_inventory(&msg, &[]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, ItemKind::FileReference);
+        assert!(items[0].downloadable);
+        assert_eq!(items[0].name.as_deref(), Some("NetskopeLogs.zip"));
+        assert!(items[0].content_url.as_deref().unwrap().ends_with(".zip"));
+    }
+
+    #[test]
+    fn code_snippet_folds_its_hosted_content() {
+        let snippet_url = "https://graph.microsoft.com/v1.0/chats/19:abc/messages/m1/hostedContents/c25pcHBldA==/$value";
+        let att = ChatMessageAttachment {
+            id: Some("snippet1".into()),
+            content_type: Some("application/vnd.microsoft.card.codesnippet".into()),
+            content: Some(format!(
+                r#"{{"language":"Rust","codeSnippetUrl":"{snippet_url}"}}"#
+            )),
+            content_url: None,
+            name: None,
+            thumbnail_url: None,
+            teams_app_id: None,
+        };
+        let msg = message_with("<p>code</p>", vec![att]);
+        // The snippet's hosted content also appears in the hostedContents list;
+        // it must not be double-counted as a standalone inline image.
+        let items = build_inventory(&msg, &[hosted("c25pcHBldA==")]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, ItemKind::CodeSnippet);
+        assert!(items[0].downloadable);
+        assert_eq!(items[0].language.as_deref(), Some("Rust"));
+        assert_eq!(items[0].code_snippet_url.as_deref(), Some(snippet_url));
+    }
+
+    #[test]
+    fn cards_and_message_references_are_listed_but_not_downloadable() {
+        let card = ChatMessageAttachment {
+            id: Some("card1".into()),
+            content_type: Some("application/vnd.microsoft.card.adaptive".into()),
+            content: Some("{}".into()),
+            content_url: None,
+            name: None,
+            thumbnail_url: None,
+            teams_app_id: None,
+        };
+        let quoted = ChatMessageAttachment {
+            id: Some("ref1".into()),
+            content_type: Some("messageReference".into()),
+            content: Some("{}".into()),
+            content_url: None,
+            name: None,
+            thumbnail_url: None,
+            teams_app_id: None,
+        };
+        let msg = message_with("<p>hi</p>", vec![card, quoted]);
+        let items = build_inventory(&msg, &[]);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].kind, ItemKind::Card);
+        assert!(!items[0].downloadable);
+        assert_eq!(items[1].kind, ItemKind::MessageReference);
+        assert!(!items[1].downloadable);
+    }
+
+    #[test]
+    fn external_and_data_uri_images_are_ignored() {
+        let body =
+            r#"<img src="https://media.giphy.com/x.gif"><img src="data:image/png;base64,AAAA">"#;
+        let msg = message_with(body, vec![]);
+        assert!(build_inventory(&msg, &[]).is_empty());
+    }
+
+    #[test]
+    fn unlisted_hosted_content_still_appears() {
+        let msg = message_with("<p>no images in body</p>", vec![]);
+        let items = build_inventory(&msg, &[hosted("b3JwaGFu")]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, ItemKind::HostedContent);
+        assert_eq!(items[0].hosted_content_id.as_deref(), Some("b3JwaGFu"));
+    }
+
+    #[test]
+    fn empty_message_yields_empty_inventory() {
+        let msg = message_with("", vec![]);
+        assert!(build_inventory(&msg, &[]).is_empty());
+    }
+
+    #[test]
+    fn percent_encoded_ids_are_decoded() {
+        let url = "https://graph.microsoft.com/v1.0/teams/t/channels/c/messages/m/hostedContents/aWQ9%2Bx%2Fz%3D%3D/$value";
+        assert_eq!(
+            hosted_content_id_from_url(url).as_deref(),
+            Some("aWQ9+x/z==")
+        );
+    }
+}

--- a/src/models/attachment_inventory.rs
+++ b/src/models/attachment_inventory.rs
@@ -205,12 +205,16 @@ fn hosted_images_in_body(html: &str) -> Vec<BodyImage> {
 /// Pull the hosted-content ID out of a Graph `.../hostedContents/{id}/$value`
 /// URL, percent-decoding it back to the raw base64 form used by the API.
 fn hosted_content_id_from_url(url: &str) -> Option<String> {
-    if !url.contains("graph.microsoft.com/") {
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("graph.microsoft.com") {
         return None;
     }
-    let after = url.rsplit_once("/hostedContents/")?.1;
-    let id = after.strip_suffix("/$value")?;
-    if id.is_empty() {
+    let mut segments = parsed
+        .path_segments()?
+        .skip_while(|s| *s != "hostedContents");
+    segments.next()?;
+    let id = segments.next().filter(|s| !s.is_empty())?;
+    if segments.next() != Some("$value") || segments.next().is_some() {
         return None;
     }
     Some(
@@ -370,8 +374,7 @@ mod tests {
 
     #[test]
     fn external_and_data_uri_images_are_ignored() {
-        let body =
-            r#"<img src="https://media.giphy.com/x.gif"><img src="data:image/png;base64,AAAA">"#;
+        let body = r#"<img src="https://media.giphy.com/x.gif"><img src="data:image/png;base64,AAAA"><img src="https://evil.example.com/graph.microsoft.com/v1.0/chats/c/messages/m/hostedContents/x/$value">"#;
         let msg = message_with(body, vec![]);
         assert!(build_inventory(&msg, &[]).is_empty());
     }

--- a/src/models/file.rs
+++ b/src/models/file.rs
@@ -14,6 +14,8 @@ pub struct DriveItem {
     pub size: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_url: Option<String>,
+    #[serde(rename = "eTag", skip_serializing_if = "Option::is_none")]
+    pub e_tag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_date_time: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -55,7 +55,7 @@ pub struct SendMessageRequest {
     pub attachments: Option<Vec<ChatMessageAttachment>>,
 }
 
-/// Message attachment (e.g., adaptive card).
+/// Message attachment (e.g., adaptive card, file reference, code snippet).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatMessageAttachment {
@@ -66,7 +66,29 @@ pub struct ChatMessageAttachment {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumbnail_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams_app_id: Option<String>,
+}
+
+/// Inline media stored with a message (pasted screenshots, code snippets).
+///
+/// The list endpoint returns `contentBytes` and `contentType` as null; actual
+/// bytes come from the per-item `/$value` endpoint and the real MIME type from
+/// that response's Content-Type header.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatMessageHostedContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_bytes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
 }
 
 /// Request body for setting/unsetting a reaction.
@@ -118,6 +140,35 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ChatMessage = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.body.unwrap().content.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn reference_attachment_keeps_content_url() {
+        let json = r#"{
+            "id": "C0F75B79-7D00-4DC9-918F-5FAEDD1086A4",
+            "contentType": "reference",
+            "contentUrl": "https://tenant-my.sharepoint.com/personal/user/Documents/NetskopeLogs.zip",
+            "content": null,
+            "name": "NetskopeLogs.zip",
+            "thumbnailUrl": null,
+            "teamsAppId": null
+        }"#;
+        let att: ChatMessageAttachment = serde_json::from_str(json).unwrap();
+        assert_eq!(att.content_type.as_deref(), Some("reference"));
+        assert_eq!(
+            att.content_url.as_deref(),
+            Some("https://tenant-my.sharepoint.com/personal/user/Documents/NetskopeLogs.zip")
+        );
+        assert_eq!(att.name.as_deref(), Some("NetskopeLogs.zip"));
+    }
+
+    #[test]
+    fn hosted_content_list_entry_has_null_bytes() {
+        let json = r#"{"id": "aWQ9eF8wLWZyY2E=", "contentBytes": null, "contentType": null}"#;
+        let hc: ChatMessageHostedContent = serde_json::from_str(json).unwrap();
+        assert_eq!(hc.id.as_deref(), Some("aWQ9eF8wLWZyY2E="));
+        assert!(hc.content_bytes.is_none());
+        assert!(hc.content_type.is_none());
     }
 
     #[test]

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -53,6 +53,21 @@ pub struct SendMessageRequest {
     pub body: ItemBody,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<ChatMessageAttachment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hosted_contents: Option<Vec<HostedContentUpload>>,
+}
+
+/// Write-side hosted content: inline image bytes riding a message create
+/// call. The body HTML references it as `../hostedContents/{temporaryId}/$value`
+/// and Graph rewrites that into a permanent URL on delivery.
+#[derive(Debug, Clone, Serialize)]
+pub struct HostedContentUpload {
+    #[serde(rename = "@microsoft.graph.temporaryId")]
+    pub temporary_id: String,
+    #[serde(rename = "contentBytes")]
+    pub content_bytes: String,
+    #[serde(rename = "contentType")]
+    pub content_type: String,
 }
 
 /// Message attachment (e.g., adaptive card, file reference, code snippet).
@@ -140,6 +155,28 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ChatMessage = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.body.unwrap().content.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn send_request_serializes_hosted_contents_with_temporary_id() {
+        let req = SendMessageRequest {
+            body: ItemBody {
+                content_type: Some("html".into()),
+                content: Some(r#"<p><img src="../hostedContents/1/$value"></p>"#.into()),
+            },
+            attachments: None,
+            hosted_contents: Some(vec![HostedContentUpload {
+                temporary_id: "1".into(),
+                content_bytes: "aVZCT1J3".into(),
+                content_type: "image/png".into(),
+            }]),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        let hc = &json["hostedContents"][0];
+        assert_eq!(hc["@microsoft.graph.temporaryId"], "1");
+        assert_eq!(hc["contentBytes"], "aVZCT1J3");
+        assert_eq!(hc["contentType"], "image/png");
+        assert!(json.get("attachments").is_none());
     }
 
     #[test]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod attachment_inventory;
 pub mod channel;
 pub mod chat;
 pub mod common;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -27,3 +27,44 @@ pub struct User {
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
+
+/// Microsoft Graph person resource, returned by the `/me/people` API.
+/// For organization users, `id` is the person's AAD user object ID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Person {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_principal_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub department: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scored_email_addresses: Option<Vec<ScoredEmailAddress>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub person_type: Option<PersonType>,
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScoredEmailAddress {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relevance_score: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonType {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subclass: Option<String>,
+}

--- a/src/output/progress.rs
+++ b/src/output/progress.rs
@@ -18,6 +18,22 @@ pub fn spinner(message: &str) -> ProgressBar {
     pb
 }
 
+/// Create a bounded progress bar for the user-resolve roster sweep.
+/// Only visible when stderr is a TTY.
+pub fn sweep_bar(total: u64) -> ProgressBar {
+    if !std::io::stderr().is_terminal() {
+        return ProgressBar::hidden();
+    }
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} Sweeping chat rosters: {pos}/{len}")
+            .unwrap()
+            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}
+
 /// Create a progress bar for --all-pages pagination.
 /// Only visible when stderr is a TTY.
 pub fn paging_bar() -> ProgressBar {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,13 @@ use std::fs;
 fn teams() -> Command {
     let mut cmd = Command::cargo_bin("teams").unwrap();
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
+    // Point the platform config-directory lookup at cargo's temp dir so the
+    // developer's real config file can't leak into assertions about
+    // out-of-box defaults. dirs resolves via $HOME on macOS and
+    // $XDG_CONFIG_HOME on Linux; Windows uses the Known Folder API and is
+    // unaffected by these overrides.
+    cmd.env("HOME", env!("CARGO_TARGET_TMPDIR"));
+    cmd.env("XDG_CONFIG_HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,6 +13,7 @@ fn teams() -> Command {
     // unaffected by these overrides.
     cmd.env("HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd.env("XDG_CONFIG_HOME", env!("CARGO_TARGET_TMPDIR"));
+    cmd.env_remove("TEAMS_CLI_SCOPES");
     cmd
 }
 
@@ -78,6 +79,65 @@ fn auth_consent_url_uses_oso_default_client_id() {
                 .and(predicate::str::contains("organizations"))
                 .and(predicate::str::contains("ChannelMessage.Read.All").not()),
         );
+}
+
+#[test]
+fn auth_login_help_documents_scopes_flag_and_env() {
+    teams()
+        .args(["auth", "login", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--scopes <SCOPES>")
+                .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_consent_url_uses_profile_scopes_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+scopes = "User.Read People.Read TeamMember.Read.All offline_access"
+"#,
+    )
+    .unwrap();
+
+    teams()
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "--profile",
+            "customer",
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("People.Read")
+                .and(predicate::str::contains("TeamMember.Read.All"))
+                .and(predicate::str::contains(
+                    "11111111-1111-1111-1111-111111111111",
+                )),
+        );
+}
+
+#[test]
+fn auth_doctor_reports_resolved_delegated_scopes() {
+    teams()
+        .args(["auth", "doctor", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"resolved_delegated_scopes\""));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -320,6 +320,25 @@ fn config_output_format_is_honored_without_cli_output_flag() {
 // --- Phase 2: Team subcommand tests ---
 
 #[test]
+fn user_help_shows_subcommands() {
+    teams().args(["user", "--help"]).assert().success().stdout(
+        predicate::str::contains("me")
+            .and(predicate::str::contains("get"))
+            .and(predicate::str::contains("list"))
+            .and(predicate::str::contains("resolve")),
+    );
+}
+
+#[test]
+fn user_resolve_help_shows_max_chats() {
+    teams()
+        .args(["user", "resolve", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--max-chats <MAX_CHATS>"));
+}
+
+#[test]
 fn team_help_shows_subcommands() {
     teams().args(["team", "--help"]).assert().success().stdout(
         predicate::str::contains("list")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,14 +6,17 @@ use std::fs;
 fn teams() -> Command {
     let mut cmd = Command::cargo_bin("teams").unwrap();
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
-    // Point the platform config-directory lookup at cargo's temp dir so the
-    // developer's real config file can't leak into assertions about
-    // out-of-box defaults. dirs resolves via $HOME on macOS and
-    // $XDG_CONFIG_HOME on Linux; Windows uses the Known Folder API and is
-    // unaffected by these overrides.
+    // Isolate tests from the developer's real environment: a configured
+    // profile or exported credentials would otherwise change command output.
+    // dirs resolves via $HOME on macOS and $XDG_CONFIG_HOME on Linux; Windows
+    // uses the Known Folder API and is unaffected by these overrides.
     cmd.env("HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd.env("XDG_CONFIG_HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd.env_remove("TEAMS_CLI_SCOPES");
+    cmd.env_remove("TEAMS_CLI_CLIENT_ID");
+    cmd.env_remove("TEAMS_CLI_CLIENT_SECRET");
+    cmd.env_remove("TEAMS_CLI_TENANT_ID");
+    cmd.env_remove("TEAMS_CLI_ACCESS_TOKEN");
     cmd
 }
 
@@ -90,6 +93,54 @@ fn auth_login_help_documents_scopes_flag_and_env() {
         .stdout(
             predicate::str::contains("--scopes <SCOPES>")
                 .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_help_shows_refresh_subcommand() {
+    teams()
+        .args(["auth", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("refresh"));
+}
+
+#[test]
+fn auth_refresh_help_documents_scopes_flag_and_env() {
+    teams()
+        .args(["auth", "refresh", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--scopes <SCOPES>")
+                .and(predicate::str::contains("TEAMS_CLI_SCOPES")),
+        );
+}
+
+#[test]
+fn auth_refresh_without_login_fails_with_auth_error() {
+    teams()
+        .args(["auth", "refresh", "--output", "json"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains("auth login"));
+}
+
+#[test]
+fn auth_consent_url_accepts_explicit_scopes() {
+    teams()
+        .args([
+            "auth",
+            "consent-url",
+            "--scopes",
+            "User.Read People.Read",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("People.Read").and(predicate::str::contains("offline_access")),
         );
 }
 


### PR DESCRIPTION
## Summary

- Release validated feature set from #35, #36, #39, #40, and #29 as v0.3.0.
- Adds per-profile delegated scopes, explicit auth refresh, user resolve, message attachment inventory/download, inline image send, and file attachment send.
- Includes review hardening: hermetic CLI test env, People API candidate verification through `/users/{userPrincipalName}`, Graph-only hosted-content URL parsing, and Graph DriveItem 250MB simple-upload limit for `--attach`.
- Refreshes the Rust dependency lockfile and updates release metadata/changelog.

## Local verification

- `cargo fmt -- --check`
- `cargo test --all-targets` (132 unit tests, 53 CLI tests)
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo audit` exits 0; one allowed transitive warning remains: RUSTSEC-2026-0097 for `rand` via `reqwest`/`quinn`.

## Release notes

This should be treated as a feature release, not a patch release. I recommend holding #6, #7, and #8 for a separate dependency-modernization pass because they are direct pre-1.0/major dependency bumps with higher compatibility risk.