### PR TITLE
Verify Homebrew publication after releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
     name: Update Homebrew Tap
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     permissions: {}
     steps:
       - name: Update homebrew formula
@@ -149,6 +150,67 @@ jobs:
               "tag": "${{ github.ref_name }}",
               "repo": "${{ github.repository }}"
             }
+
+      - name: Verify homebrew formula was published
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          checksums_file="$(mktemp)"
+          trap 'rm -f "$checksums_file"' EXIT
+          curl --fail --location --silent --show-error \
+            --retry 5 --retry-all-errors \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/checksums-sha256.txt" \
+            --output "$checksums_file"
+
+          targets=(
+            aarch64-apple-darwin
+            x86_64-apple-darwin
+            aarch64-unknown-linux-musl
+            x86_64-unknown-linux-musl
+          )
+
+          for attempt in $(seq 1 30); do
+            formula="$(
+              curl --fail --silent --show-error \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header "Accept: application/vnd.github.raw+json" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/osodevops/homebrew-tap/contents/Formula/teams-cli.rb?ref=main"
+            )" || formula=""
+
+            published=true
+            for target in "${targets[@]}"; do
+              asset="teams-${RELEASE_TAG}-${target}.tar.gz"
+              checksum="$(awk -v asset="$asset" '$2 == asset { print $1 }' "$checksums_file")"
+              if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "Release checksums are missing a valid SHA-256 for ${asset}" >&2
+                exit 1
+              fi
+
+              url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${asset}"
+              if ! grep -Fq "$url" <<<"$formula" ||
+                ! grep -Fq "sha256 \"${checksum}\"" <<<"$formula"; then
+                published=false
+                break
+              fi
+            done
+
+            if [[ "$published" == true ]]; then
+              echo "Homebrew formula publishes ${RELEASE_TAG} with all expected checksums"
+              exit 0
+            fi
+
+            echo "Waiting for the Homebrew tap to publish ${RELEASE_TAG} (attempt ${attempt}/30)"
+            sleep 10
+          done
+
+          echo "Homebrew tap did not publish ${RELEASE_TAG} within five minutes" >&2
+          echo "Check https://github.com/osodevops/homebrew-tap/actions" >&2
+          exit 1
 
   publish-scoop-manifest:
     name: Publish Scoop Manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.
+
 ## v0.3.0 - 2026-07-09
 
 ### Added

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -66,7 +66,7 @@ The full release path is version-bump driven, not PR-merge driven:
 4. After the PR is merged to `main`, confirm `.github/workflows/auto-tag.yml` runs successfully.
 5. Confirm `auto-tag.yml` creates the `vX.Y.Z` tag.
 6. Confirm the tag starts `.github/workflows/release.yml`.
-7. Confirm the release workflow completes all build targets, creates checksums, publishes the GitHub Release, and runs the Homebrew tap and Scoop bucket update jobs.
+7. Confirm the release workflow completes all build targets, creates checksums, publishes the GitHub Release, and runs the Homebrew tap and Scoop bucket update jobs. The Homebrew job must verify the published formula before it succeeds.
 
 Important details:
 
@@ -80,14 +80,14 @@ Important details:
   - `aarch64-unknown-linux-musl`
   - `x86_64-pc-windows-msvc`
 
-Distribution follow-up as of 2026-06-21:
+Distribution automation as of 2026-07-10:
 
 - `release.yml` sends a `repository_dispatch` event to `osodevops/homebrew-tap`.
 - `release.yml` sends a `repository_dispatch` event to `osodevops/scoop-bucket`.
-- The tap repository currently has no workflow listening for that dispatch event.
-- Until that automation exists, update `osodevops/homebrew-tap` manually after each CLI release.
-- Use the published `checksums-sha256.txt` from the GitHub Release to update `Formula/teams-cli.rb`.
-- Verify the remote formula points at the new release URLs and checksums.
+- The tap's `update-teams-formula.yml` workflow validates the source repository and tag, downloads the published `checksums-sha256.txt`, updates all four macOS/Linux artifact blocks, and commits `Formula/teams-cli.rb`.
+- The CLI release job polls the remote formula and fails after five minutes unless all four release URLs and SHA-256 values are present. A successful dispatch alone is not considered publication.
+- The tap workflow also supports a manual `workflow_dispatch` with a `tag` input for recovery or backfill.
+- After a release, verify the remote formula and the Homebrew workflow run as well as the source release run.
 - The Scoop release job uses `SCOOP_BUCKET_TOKEN`, matching the dedicated bucket-token pattern used by `osodevops/kafka-backup`.
 - The Scoop bucket has an `update-teams-manifest` workflow listener. Verify `bucket/teams.json` points at the new Windows release URL and checksum after each release.
 


### PR DESCRIPTION
## Root cause

The v0.3.0 release workflow successfully sent an `update-formula` repository dispatch, but `osodevops/homebrew-tap` had no workflow listening for that event. GitHub returned success for the accepted event, so the release stayed green while `Formula/teams-cli.rb` remained on v0.2.7.

The missing tap listener was added in osodevops/homebrew-tap#3 and exercised successfully for v0.3.0.

## Changes

- poll the published tap formula after dispatch
- verify all four macOS/Linux release URLs and SHA-256 values
- fail the Homebrew release job after five minutes if publication did not happen
- update release documentation and changelog

## Verification

- `actionlint .github/workflows/release.yml .github/workflows/auto-tag.yml .github/workflows/ci.yml`
- live verifier logic against the published v0.3.0 formula
- `cargo fmt -- --check`
- `cargo test --all-targets` (185 tests passed)