### PR TITLE
Update keyring items in place instead of delete-and-recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Token storage no longer deletes and recreates the keyring item on every write. On macOS the recreation discarded the item's access control list, so an "Always Allow" grant was revoked by the next silent token refresh and the keychain prompt returned within the hour. Items are now updated in place, which preserves the grant. This resolves #51.
 - Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.
 
 ## v0.3.0 - 2026-07-09

--- a/src/auth/keyring.rs
+++ b/src/auth/keyring.rs
@@ -26,9 +26,11 @@ pub fn store_token(profile: &str, token: &TokenInfo) -> Result<()> {
     let json = serde_json::to_string(token)
         .map_err(|e| TeamsError::KeyringError(format!("Failed to serialize token: {e}")))?;
 
+    // Update in place rather than delete-and-recreate: recreating the item
+    // discards its access control list on macOS, so every silent token
+    // refresh would revoke a previously granted "Always Allow".
     let entry = ::keyring::Entry::new(SERVICE_NAME, &key)
         .map_err(|e| TeamsError::KeyringError(format!("Failed to create keyring entry: {e}")))?;
-    entry.delete_credential().ok();
     entry
         .set_password(&json)
         .map_err(|e| TeamsError::KeyringError(format!("Failed to store token: {e}")))?;
@@ -88,15 +90,7 @@ pub fn add_profile_to_index(profile: &str) -> Result<()> {
     if !profiles.contains(&profile.to_string()) {
         profiles.push(profile.to_string());
     }
-    let json = serde_json::to_string(&profiles)
-        .map_err(|e| TeamsError::KeyringError(format!("Failed to serialize index: {e}")))?;
-    let entry = ::keyring::Entry::new(SERVICE_NAME, "profile-index")
-        .map_err(|e| TeamsError::KeyringError(format!("Failed to create keyring entry: {e}")))?;
-    entry.delete_credential().ok();
-    entry
-        .set_password(&json)
-        .map_err(|e| TeamsError::KeyringError(format!("Failed to store index: {e}")))?;
-    Ok(())
+    write_profile_index(&profiles)
 }
 
 pub fn remove_profile_from_index(profile: &str) -> Result<()> {
@@ -106,11 +100,14 @@ pub fn remove_profile_from_index(profile: &str) -> Result<()> {
 
     let mut profiles = list_profiles();
     profiles.retain(|p| p != profile);
-    let json = serde_json::to_string(&profiles)
+    write_profile_index(&profiles)
+}
+
+fn write_profile_index(profiles: &[String]) -> Result<()> {
+    let json = serde_json::to_string(profiles)
         .map_err(|e| TeamsError::KeyringError(format!("Failed to serialize index: {e}")))?;
     let entry = ::keyring::Entry::new(SERVICE_NAME, "profile-index")
         .map_err(|e| TeamsError::KeyringError(format!("Failed to create keyring entry: {e}")))?;
-    entry.delete_credential().ok();
     entry
         .set_password(&json)
         .map_err(|e| TeamsError::KeyringError(format!("Failed to store index: {e}")))?;


### PR DESCRIPTION
Fixes #51.

`store_token`, `add_profile_to_index`, and `remove_profile_from_index` deleted the keyring item before every `set_password` call. On macOS the recreation discards the item's access control list, so an "Always Allow" grant was revoked by the next silent token refresh and the keychain prompt returned within the hour.

`keyring` v3 `set_password` already updates an existing item in place (its macOS backend is create-or-update), so the delete calls are removed. The two index writers shared the same storage block and now use one `write_profile_index` helper.

Verified on macOS 15 against a live login: after this change, `security find-generic-password -s teams-cli -a "default:token"` shows an unchanged creation date and an updated modification date following `teams auth refresh`. Before the change the creation date moved on every write, proving the item was recreated.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --bins` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXWLJ9g87M3GtLSACr2gmi