### PR TITLE
Send prompt=select_account on browser login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Browser login now sends `prompt=select_account`, so the identity platform always shows the account picker instead of silently reusing an existing browser session. This makes it possible to sign a second account into another profile with `teams --profile <name> auth login`. This resolves #52.
+
 ### Fixed
 
 - Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -118,6 +118,11 @@ Browser PKCE login:
 teams auth login
 ```
 
+The browser flow always shows the Microsoft account picker
+(`prompt=select_account`), so an existing browser session is never reused
+silently. This is what lets you sign a second account into another profile,
+for example `teams --profile alt auth login`.
+
 Device-code login:
 
 ```bash

--- a/src/auth/auth_code_pkce.rs
+++ b/src/auth/auth_code_pkce.rs
@@ -28,6 +28,33 @@ fn generate_pkce() -> Result<(String, String)> {
     Ok((verifier, challenge))
 }
 
+/// Build the authorization URL for the browser login.
+///
+/// `prompt=select_account` forces the account picker. Without it the identity
+/// platform silently reuses an existing browser session, which makes it
+/// impossible to sign a second account into another profile.
+fn build_authorize_url(
+    client_id: &str,
+    tenant_id: &str,
+    scopes: &str,
+    state: &str,
+    challenge: &str,
+) -> String {
+    format!(
+        "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?\
+         client_id={client_id}\
+         &response_type=code\
+         &redirect_uri={}\
+         &scope={}\
+         &state={state}\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &prompt=select_account",
+        urlencoding::encode(DEFAULT_REDIRECT_URI),
+        urlencoding::encode(scopes),
+    )
+}
+
 /// Authenticate using authorization code flow with PKCE.
 /// Opens a browser and starts a loopback HTTP server to receive the callback.
 pub async fn authenticate(
@@ -40,18 +67,7 @@ pub async fn authenticate(
 
     let state = random_urlsafe_bytes(16)?;
 
-    let auth_url = format!(
-        "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?\
-         client_id={client_id}\
-         &response_type=code\
-         &redirect_uri={}\
-         &scope={}\
-         &state={state}\
-         &code_challenge={challenge}\
-         &code_challenge_method=S256",
-        urlencoding::encode(DEFAULT_REDIRECT_URI),
-        urlencoding::encode(scopes),
-    );
+    let auth_url = build_authorize_url(client_id, tenant_id, scopes, &state, &challenge);
 
     // Start loopback server
     let (tx, rx) = oneshot::channel::<String>();
@@ -166,4 +182,37 @@ pub async fn authenticate(
     resp.json::<MsTokenResponse>()
         .await
         .map_err(|e| TeamsError::AuthError(format!("Failed to parse token response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_contains_expected_parameters() {
+        let url = build_authorize_url(
+            "client-1",
+            "tenant-1",
+            "User.Read offline_access",
+            "st4te",
+            "ch4llenge",
+        );
+
+        assert!(
+            url.starts_with("https://login.microsoftonline.com/tenant-1/oauth2/v2.0/authorize?")
+        );
+        assert!(url.contains("client_id=client-1"));
+        assert!(url.contains("&response_type=code"));
+        assert!(url.contains("&scope=User.Read%20offline_access"));
+        assert!(url.contains("&state=st4te"));
+        assert!(url.contains("&code_challenge=ch4llenge"));
+        assert!(url.contains("&code_challenge_method=S256"));
+    }
+
+    #[test]
+    fn authorize_url_forces_account_picker() {
+        let url = build_authorize_url("client-1", "tenant-1", "User.Read", "s", "c");
+
+        assert!(url.contains("&prompt=select_account"));
+    }
 }


### PR DESCRIPTION
Fixes #52.

The authorization URL for the browser (auth code + PKCE) flow had no `prompt` parameter, so a browser with an existing Microsoft session was signed in silently. That made it impossible to sign a second account into another profile through the default flow — `teams --profile alt auth login` stored a token for the already-signed-in user. Only device code offered an account picker.

The URL now includes `prompt=select_account`, matching common multi-account CLI behavior. Cost is one extra click per login for single-account users; logins are rare.

URL construction moves into `build_authorize_url` with tests covering the existing parameters and the new prompt.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --bins` pass (134 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXWLJ9g87M3GtLSACr2gmi