### PR TITLE
Add TEAMS_CLI_PROFILE and stop shadowing the "default" profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- `TEAMS_CLI_PROFILE` environment variable for selecting the credential profile, with the same precedence as other auth environment variables: `--profile` flag, then `TEAMS_CLI_PROFILE`, then the config's `default.profile`, then `default`. This resolves #53.
+
 ### Changed
 
 - Browser login now sends `prompt=select_account`, so the identity platform always shows the account picker instead of silently reusing an existing browser session. This makes it possible to sign a second account into another profile with `teams --profile <name> auth login`. This resolves #52.
 
 ### Fixed
 
+- An explicit `--profile default` now addresses the profile named "default" even after `teams auth switch` has set another config default. Previously the flag's default value was indistinguishable from an explicit one, so the switched profile shadowed the literal "default" profile and it became unreachable from the command line. This resolves #55.
 - Token storage no longer deletes and recreates the keyring item on every write. On macOS the recreation discarded the item's access control list, so an "Always Allow" grant was revoked by the next silent token refresh and the keychain prompt returned within the hour. Items are now updated in place, which preserves the grant. This resolves #51.
 - Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.
 

--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ auth_flow = "device-code"
 | `TEAMS_CLI_CLIENT_ID` | Azure AD application (client) ID |
 | `TEAMS_CLI_CLIENT_SECRET` | Azure AD client secret |
 | `TEAMS_CLI_TENANT_ID` | Azure AD tenant ID |
+| `TEAMS_CLI_PROFILE` | Named credential profile (overridden by `--profile`; an explicit value beats the config's `default.profile`) |
 | `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login (same precedence as `--scopes`; ignored by client credentials) |
 | `TEAMS_CLI_ACCESS_TOKEN` | Pre-obtained Microsoft Graph access token (skips login entirely) |
 | `RUST_LOG` | Tracing filter (e.g., `debug`, `teams=trace`) |

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ auth_flow = "device-code"
 | `TEAMS_CLI_TENANT_ID` | Azure AD tenant ID |
 | `TEAMS_CLI_PROFILE` | Named credential profile (overridden by `--profile`; an explicit value beats the config's `default.profile`) |
 | `TEAMS_CLI_SCOPES` | Delegated OAuth scopes for login (same precedence as `--scopes`; ignored by client credentials) |
-| `TEAMS_CLI_ACCESS_TOKEN` | Pre-obtained Microsoft Graph access token (skips login entirely) |
+| `TEAMS_CLI_ACCESS_TOKEN` | Pre-obtained Microsoft Graph access token (skips login entirely; `--profile`/`TEAMS_CLI_PROFILE` do not affect which token is used) |
 | `RUST_LOG` | Tracing filter (e.g., `debug`, `teams=trace`) |
 
 ## Verbosity

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -289,7 +289,8 @@ teams auth logout --all
 
 | Variable | Purpose |
 | --- | --- |
-| `TEAMS_CLI_ACCESS_TOKEN` | Use this bearer token instead of the keyring token. |
+| `TEAMS_CLI_ACCESS_TOKEN` | Use this bearer token instead of the keyring token. When set, `--profile` and `TEAMS_CLI_PROFILE` do not affect which token is used. |
+| `TEAMS_CLI_PROFILE` | Named credential profile. Precedence: `--profile`, then `TEAMS_CLI_PROFILE`, then the config's `default.profile`, then `default`. |
 | `TEAMS_CLI_CLIENT_ID` | Entra app client ID. |
 | `TEAMS_CLI_CLIENT_SECRET` | Client secret for client credentials flow. |
 | `TEAMS_CLI_TENANT_ID` | Tenant ID or tenant domain. |

--- a/docs/man/teams-auth.7
+++ b/docs/man/teams-auth.7
@@ -138,6 +138,11 @@ The config file stores profile and app settings, not access tokens.
 .B TEAMS_CLI_ACCESS_TOKEN
 Use a pre-obtained bearer token and skip keyring lookup.
 .TP
+.B TEAMS_CLI_PROFILE
+Named credential profile. Overridden by
+.B --profile;
+overrides the config file's default profile.
+.TP
 .B TEAMS_CLI_CLIENT_ID
 Entra app client ID.
 .TP

--- a/docs/man/teams-config.5
+++ b/docs/man/teams-config.5
@@ -51,10 +51,15 @@ scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 .SH DEFAULT SECTION
 .TP
 .B profile
-Default profile used when
+Default profile used when neither
 .B --profile
-is not supplied or is
-.B default.
+nor
+.B TEAMS_CLI_PROFILE
+is supplied. An explicit
+.B --profile default
+always addresses the profile named
+.B default,
+even when this setting points elsewhere.
 .TP
 .B output
 Default output format override. Valid values are
@@ -137,6 +142,14 @@ built-in default delegated scopes;
 .B offline_access
 is appended when missing. Ignored by client credentials login.
 .SH RESOLUTION ORDER
+Profile resolution:
+.nf
+1. --profile flag
+2. TEAMS_CLI_PROFILE
+3. [default] profile in the config file
+4. default
+.fi
+.PP
 Client ID and tenant ID resolution:
 .nf
 1. CLI flag

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -33,9 +33,12 @@ Disable ANSI color codes.
 Read and write configuration at PATH instead of the platform default.
 .TP
 .B --profile NAME
-Use a named credential profile. Defaults to
-.B default
-or the configured default profile.
+Use a named credential profile. Falls back to
+.B TEAMS_CLI_PROFILE,
+then the configured default profile, then
+.B default.
+An explicit NAME always wins, even when it is the literal
+.B default.
 .TP
 .B --timeout SECONDS
 Override Graph request timeout.
@@ -289,6 +292,10 @@ Azure AD client secret for client credentials auth.
 .TP
 .B TEAMS_CLI_TENANT_ID
 Azure AD tenant ID.
+.TP
+.B TEAMS_CLI_PROFILE
+Named credential profile. Overridden by
+.B --profile.
 .TP
 .B TEAMS_CLI_SCOPES
 Delegated OAuth scopes for login. Same precedence as

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,9 +53,9 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub config: Option<String>,
 
-    /// Named credential profile
-    #[arg(long, global = true, default_value = "default")]
-    pub profile: String,
+    /// Named credential profile (defaults to "default")
+    #[arg(long, global = true, env = "TEAMS_CLI_PROFILE")]
+    pub profile: Option<String>,
 
     /// Request timeout in seconds
     #[arg(long, global = true)]
@@ -177,7 +177,7 @@ pub async fn run(cli: Cli, config: &ConfigFile) -> Result<()> {
         cli.output.as_deref(),
         config,
     ));
-    let profile = crate::config::resolve_profile(&cli.profile, config).to_string();
+    let profile = crate::config::resolve_profile(cli.profile.as_deref(), config).to_string();
     let mut runtime_config = config.clone();
     runtime_config.network =
         crate::config::effective_network_config(config, cli.timeout, cli.retry);

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,11 +164,15 @@ pub fn save_config(config: &ConfigFile, path: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-pub fn resolve_profile<'a>(cli_profile: &'a str, config: &'a ConfigFile) -> &'a str {
-    if cli_profile != "default" {
-        return cli_profile;
+/// Resolve the active profile: an explicit `--profile` flag or
+/// `TEAMS_CLI_PROFILE` value (delivered via clap) wins even when it is the
+/// literal "default", so `auth switch` cannot shadow a profile of that name;
+/// otherwise the config's `default.profile`, then "default".
+pub fn resolve_profile<'a>(cli_profile: Option<&'a str>, config: &'a ConfigFile) -> &'a str {
+    match cli_profile {
+        Some(profile) => profile,
+        None => config.default.profile.as_deref().unwrap_or("default"),
     }
-    config.default.profile.as_deref().unwrap_or("default")
 }
 
 pub fn resolve_client_id(
@@ -409,14 +413,29 @@ scopes = "User.Read People.Read offline_access"
     #[test]
     fn resolve_profile_uses_cli_override() {
         let config = ConfigFile::default();
-        assert_eq!(resolve_profile("custom", &config), "custom");
+        assert_eq!(resolve_profile(Some("custom"), &config), "custom");
     }
 
     #[test]
     fn resolve_profile_uses_config_default() {
         let mut config = ConfigFile::default();
         config.default.profile = Some("work".into());
-        assert_eq!(resolve_profile("default", &config), "work");
+        assert_eq!(resolve_profile(None, &config), "work");
+    }
+
+    #[test]
+    fn resolve_profile_falls_back_to_default_name() {
+        let config = ConfigFile::default();
+        assert_eq!(resolve_profile(None, &config), "default");
+    }
+
+    #[test]
+    fn resolve_profile_explicit_default_beats_config_default() {
+        // An explicit --profile default must address the profile named
+        // "default" even after `auth switch` set another config default.
+        let mut config = ConfigFile::default();
+        config.default.profile = Some("work".into());
+        assert_eq!(resolve_profile(Some("default"), &config), "default");
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,7 @@ fn teams() -> Command {
     // uses the Known Folder API and is unaffected by these overrides.
     cmd.env("HOME", env!("CARGO_TARGET_TMPDIR"));
     cmd.env("XDG_CONFIG_HOME", env!("CARGO_TARGET_TMPDIR"));
+    cmd.env_remove("TEAMS_CLI_PROFILE");
     cmd.env_remove("TEAMS_CLI_SCOPES");
     cmd.env_remove("TEAMS_CLI_CLIENT_ID");
     cmd.env_remove("TEAMS_CLI_CLIENT_SECRET");
@@ -180,6 +181,123 @@ scopes = "User.Read People.Read TeamMember.Read.All offline_access"
                     "11111111-1111-1111-1111-111111111111",
                 )),
         );
+}
+
+fn write_customer_profile_config(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+"#,
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn profile_env_var_selects_profile() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_customer_profile_config(&dir);
+
+    teams()
+        .env("TEAMS_CLI_PROFILE", "customer")
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "11111111-1111-1111-1111-111111111111",
+        ));
+}
+
+#[test]
+fn profile_flag_beats_profile_env_var() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_customer_profile_config(&dir);
+
+    // The env var points at the BYO profile; the flag selects the built-in
+    // default profile, so the OSO public client id must win.
+    teams()
+        .env("TEAMS_CLI_PROFILE", "customer")
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "--profile",
+            "default",
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595")
+                .and(predicate::str::contains("11111111-1111-1111-1111-111111111111").not()),
+        );
+}
+
+#[test]
+fn explicit_default_profile_ignores_config_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+[default]
+profile = "customer"
+
+[profiles.customer]
+auth_app = "byo"
+client_id = "11111111-1111-1111-1111-111111111111"
+tenant_id = "22222222-2222-2222-2222-222222222222"
+"#,
+    )
+    .unwrap();
+
+    // Without the flag the config default applies; with an explicit
+    // --profile default the profile named "default" must be addressable.
+    teams()
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "11111111-1111-1111-1111-111111111111",
+        ));
+
+    teams()
+        .args([
+            "--config",
+            path.to_str().unwrap(),
+            "--profile",
+            "default",
+            "auth",
+            "consent-url",
+            "--output",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #53.
Fixes #55.

The global `--profile` flag becomes `Option<String>` with a `TEAMS_CLI_PROFILE` environment fallback, so scripts and agents can select a profile once per session instead of repeating the flag on every invocation. Precedence: `--profile` flag, then `TEAMS_CLI_PROFILE`, then the config's `default.profile`, then `default` — the same shape as the other auth environment variables.

Making the flag optional also distinguishes "not given" from an explicit `--profile default`. Previously the two were identical, so after `teams auth switch <other>` the switched profile shadowed the profile literally named "default" and it became unreachable from the command line; even `--profile default auth login` stored its token under the switched name. An explicit value now always wins, even when it is the literal `default`.

Unit tests cover the new `resolve_profile` precedence including the shadowing regression; integration tests cover environment selection, flag-beats-environment, and explicit-`default`-beats-config-default. The test harness now scrubs `TEAMS_CLI_PROFILE` alongside the other inherited auth variables. README and `teams(1)` document the variable.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` pass (134 unit + 56 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXWLJ9g87M3GtLSACr2gmi