### PR TITLE
Handle broken stdout pipes without panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - An explicit `--profile default` now addresses the profile named "default" even after `teams auth switch` has set another config default. Previously the flag's default value was indistinguishable from an explicit one, so the switched profile shadowed the literal "default" profile and it became unreachable from the command line. This resolves #55.
 - Token storage no longer deletes and recreates the keyring item on every write. On macOS the recreation discarded the item's access control list, so an "Always Allow" grant was revoked by the next silent token refresh and the keychain prompt returned within the hour. Items are now updated in place, which preserves the grant. This resolves #51.
+- A closed stdout pipe (for example `teams completions bash | head`) no longer panics with exit 101. Stdout writes are centralized in `output::write_stdout` / `write_stdout_line`; a broken pipe is treated as normal early termination (exit 0, nothing on stderr), and a command that fails while its pipe closes still exits with its real error code. This resolves #59.
 - Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.
 
 ## v0.3.0 - 2026-07-09

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ On failure:
 | 8 | Server error (5xx) | Retry with backoff |
 | 10 | Configuration error | Check config/env vars |
 
+A closed stdout pipe (e.g. `teams team list | head -1`) is treated as normal early termination: exit 0, nothing on stderr. Errors that occur while the pipe is already closed still return their real exit code.
+
 **Output auto-detection**: When stdout is a TTY, output defaults to human-readable tables. When piped (which is how agents call it), output defaults to JSON. Override with `--output json|human|plain`.
 
 ## Install

--- a/docs/man/teams-agent-contract.7
+++ b/docs/man/teams-agent-contract.7
@@ -81,6 +81,12 @@ Server error after configured retries.
 .TP
 .B 10
 Configuration or keyring error.
+.PP
+A closed stdout pipe (for example when piping into
+.B head\c
+) is treated as normal early termination: the process exits 0 with nothing on
+stderr. If a command fails while its stdout pipe is already closed, the real
+error code is still returned even though the error envelope cannot be written.
 .SH RETRY AND PAGINATION
 Microsoft Graph calls go through a shared client that applies request timeout,
 bearer authentication, retries, and pagination. HTTP 429 honors

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -443,7 +443,7 @@ pub async fn run(
                 }
                 _ => {
                     // bearer (default) — just print the token
-                    println!("{}", token.access_token);
+                    output::write_stdout_line(&token.access_token);
                 }
             }
             Ok(())

--- a/src/cli/file.rs
+++ b/src/cli/file.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use std::io::{self, Read as IoRead, Write as IoWrite};
+use std::io::{self, Read as IoRead};
 use std::time::Instant;
 
 use crate::api::{self, GraphClient, PaginationOpts};
@@ -221,11 +221,7 @@ pub async fn run(
                     output::print_success(format, &result, start);
                 }
             } else {
-                io::stdout().write_all(&bytes).map_err(|e| {
-                    crate::error::TeamsError::InvalidInput(format!(
-                        "Failed to write to stdout: {e}"
-                    ))
-                })?;
+                output::write_stdout(&bytes);
             }
             Ok(())
         }

--- a/src/cli/meeting.rs
+++ b/src/cli/meeting.rs
@@ -163,7 +163,7 @@ pub async fn run(
             let meeting = api::meetings::get_meeting(&client, &meeting_id).await?;
             let url = meeting.join_web_url.unwrap_or_default();
             if format == OutputFormat::Plain {
-                println!("{}", url);
+                output::write_stdout_line(&url);
             } else {
                 let result = serde_json::json!({"joinWebUrl": url});
                 output::print_success(format, &result, start);

--- a/src/cli/message_attachments.rs
+++ b/src/cli/message_attachments.rs
@@ -1,4 +1,3 @@
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -123,9 +122,7 @@ pub async fn run(
             if path.as_deref() == Some("-") {
                 let item = selected[0];
                 let (bytes, _) = fetch_item_bytes(client, &message_ref, item).await?;
-                std::io::stdout().write_all(&bytes).map_err(|e| {
-                    TeamsError::InvalidInput(format!("Failed to write stdout: {e}"))
-                })?;
+                output::write_stdout(&bytes);
                 return Ok(());
             }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,13 +18,11 @@ pub mod tag;
 pub mod team;
 pub mod user;
 
-use clap::{Parser, Subcommand};
-use std::io::Write as _;
-
 use crate::api::PaginationOpts;
 use crate::config::ConfigFile;
 use crate::error::{Result, TeamsError};
 use crate::output::OutputFormat;
+use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -256,9 +254,6 @@ fn generate_completions(shell: clap_complete::Shell) -> Result<()> {
         .join()
         .map_err(|_| TeamsError::Other(anyhow::anyhow!("Completion generator panicked")))?;
 
-    std::io::stdout().write_all(&output).map_err(|e| {
-        TeamsError::Other(anyhow::anyhow!(
-            "Failed to write completions to stdout: {e}"
-        ))
-    })
+    crate::output::write_stdout(&output);
+    Ok(())
 }

--- a/src/listen/handler.rs
+++ b/src/listen/handler.rs
@@ -3,6 +3,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::{Method, Request, Response, StatusCode};
 
 use crate::models::subscription::ChangeNotificationCollection;
+use crate::output;
 
 type HandlerResult = std::result::Result<Response<Full<Bytes>>, hyper::Error>;
 
@@ -28,7 +29,7 @@ pub async fn handle_request(req: Request<Incoming>) -> HandlerResult {
                 Ok(collection) => {
                     for notification in &collection.value {
                         let json = serde_json::to_string(notification).unwrap_or_default();
-                        println!("{json}");
+                        output::write_stdout_line(&json);
                     }
                     Ok(ok_response(""))
                 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,11 +1,14 @@
 use serde::Serialize;
 
 pub fn print<T: Serialize>(value: &T) {
-    let json = serde_json::to_string_pretty(value).unwrap_or_else(|e| {
+    super::write_stdout_line(&serialize(value));
+}
+
+pub fn serialize<T: Serialize>(value: &T) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|e| {
         format!(
             r#"{{"success":false,"error":{{"code":"SERIALIZE_ERROR","message":"{}"}}}}"#,
             e
         )
-    });
-    println!("{json}");
+    })
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,7 +6,7 @@ pub mod table;
 use crate::error::TeamsError;
 use crate::models::common::{Envelope, Metadata};
 use serde::Serialize;
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal, Write};
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,6 +33,38 @@ impl OutputFormat {
     }
 }
 
+/// Write bytes to stdout, treating a closed pipe as normal early termination.
+pub fn write_stdout(bytes: &[u8]) {
+    handle_stdout_result(try_write_stdout(bytes));
+}
+
+/// Write a line to stdout, treating a closed pipe as normal early termination.
+pub fn write_stdout_line(line: &str) {
+    handle_stdout_result(try_write_stdout_line(line));
+}
+
+fn try_write_stdout(bytes: &[u8]) -> io::Result<()> {
+    io::stdout().lock().write_all(bytes)
+}
+
+fn try_write_stdout_line(line: &str) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    stdout.write_all(line.as_bytes())?;
+    stdout.write_all(b"\n")
+}
+
+fn handle_stdout_result(result: io::Result<()>) {
+    if let Err(err) = result {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            std::process::exit(0);
+        }
+
+        eprintln!("Error: Failed to write to stdout: {err}");
+        std::process::exit(1);
+    }
+}
+
 pub fn print_success<T: Serialize>(format: OutputFormat, data: &T, start: Instant) {
     let metadata = Metadata::new().with_duration(start.elapsed().as_millis() as u64);
     match format {
@@ -42,7 +74,7 @@ pub fn print_success<T: Serialize>(format: OutputFormat, data: &T, start: Instan
         }
         OutputFormat::Human => {
             let output = serde_json::to_string_pretty(data).unwrap_or_default();
-            println!("{output}");
+            write_stdout_line(&output);
         }
         OutputFormat::Plain => {
             plain::print_object(data);
@@ -59,7 +91,7 @@ pub fn print_success_list<T: Serialize>(format: OutputFormat, data: &[T], start:
         }
         OutputFormat::Human => {
             let output = serde_json::to_string_pretty(data).unwrap_or_default();
-            println!("{output}");
+            write_stdout_line(&output);
         }
         OutputFormat::Plain => {
             plain::print_list(data);
@@ -72,7 +104,12 @@ pub fn print_error(format: OutputFormat, err: &TeamsError) {
     match format {
         OutputFormat::Json => {
             let envelope = Envelope::<()>::error(err.error_code(), err.to_string(), metadata);
-            json::print(&envelope);
+            let output = json::serialize(&envelope);
+            if let Err(write_err) = try_write_stdout_line(&output) {
+                if write_err.kind() != io::ErrorKind::BrokenPipe {
+                    eprintln!("Error: Failed to write error response to stdout: {write_err}");
+                }
+            }
         }
         OutputFormat::Human | OutputFormat::Plain => {
             eprintln!("Error: {err}");

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -13,14 +13,11 @@ pub fn print_object<T: Serialize>(data: &T) {
                 serde_json::Value::String(s) => s.clone(),
                 other => other.to_string(),
             };
-            println!("{key}: {display}");
+            super::write_stdout_line(&format!("{key}: {display}"));
         }
     } else {
         // Fallback for non-objects
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&value).unwrap_or_default()
-        );
+        super::write_stdout_line(&serde_json::to_string_pretty(&value).unwrap_or_default());
     }
 }
 
@@ -43,7 +40,7 @@ pub fn print_list<T: Serialize>(items: &[T]) {
     };
 
     // Print header row
-    println!("{}", headers.join("\t"));
+    super::write_stdout_line(&headers.join("\t"));
 
     // Print data rows
     for val in &values {
@@ -56,7 +53,7 @@ pub fn print_list<T: Serialize>(items: &[T]) {
                     Some(other) => other.to_string(),
                 })
                 .collect();
-            println!("{}", row.join("\t"));
+            super::write_stdout_line(&row.join("\t"));
         }
     }
 }

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -7,5 +7,5 @@ pub fn print_table(headers: Vec<&str>, rows: Vec<Vec<String>>) {
     for row in rows {
         table.add_row(row);
     }
-    println!("{table}");
+    super::write_stdout_line(&table.to_string());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,9 +2,11 @@ use assert_cmd::Command;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use predicates::prelude::*;
 use std::fs;
+use std::io::Read;
+use std::process::Stdio;
 
-fn teams() -> Command {
-    let mut cmd = Command::cargo_bin("teams").unwrap();
+fn teams_process() -> std::process::Command {
+    let mut cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin!("teams"));
     cmd.env("TEAMS_CLI_DISABLE_KEYRING", "1");
     // Isolate tests from the developer's real environment: a configured
     // profile or exported credentials would otherwise change command output.
@@ -19,6 +21,10 @@ fn teams() -> Command {
     cmd.env_remove("TEAMS_CLI_TENANT_ID");
     cmd.env_remove("TEAMS_CLI_ACCESS_TOKEN");
     cmd
+}
+
+fn teams() -> Command {
+    Command::from_std(teams_process())
 }
 
 #[test]
@@ -351,6 +357,30 @@ fn completions_generates_output() {
         .assert()
         .success()
         .stdout(predicate::str::contains("teams"));
+}
+
+#[test]
+fn closed_stdout_pipe_does_not_panic() {
+    let mut child = teams_process()
+        .args(["completions", "bash"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stdout = child.stdout.take().unwrap();
+    let mut first_byte = [0_u8; 1];
+    stdout.read_exact(&mut first_byte).unwrap();
+    drop(stdout);
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "status: {}; stderr: {stderr}",
+        output.status
+    );
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #59.

When the reader side of a stdout pipe closes early (for example `teams completions bash | head`), writes to stdout fail with a broken-pipe error. Some paths returned that error to `main`, which then tried to print a JSON error envelope to the same closed pipe; other paths used `println!`, which panics on a failed write. The process exited 101 with a panic message on stderr.

Stdout writes are now centralized in `output::write_stdout` and `output::write_stdout_line`. A broken pipe is treated as normal early termination: exit 0, nothing on stderr. Any other stdout write error prints to stderr and exits 1. The error-envelope path only swallows the broken-pipe write error instead of exiting, so a command that fails while its pipe closes still exits with its real error code.

All stdout call sites are converted: JSON, human, plain, and table output, shell completions, raw file and attachment bytes, bearer token export, meeting join URLs, and listen-mode notification streaming. No bare `println!` to stdout remains in `src/`.

Verification:

- `teams completions bash | head -c 1` exits 0 with empty stderr; before the change it exits 101 with `failed printing to stdout: Broken pipe (os error 32)`.
- An unauthenticated `teams team list | head -c 1` still exits 3, so error codes survive a closed pipe.
- New integration test spawns the CLI, reads one byte, closes the pipe, and asserts a clean exit with empty stderr.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` pass (132 unit + 54 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXWLJ9g87M3GtLSACr2gmi