### PR TITLE
Document macOS keychain prompts and update the AGENTS.md auth command list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ For new command domains, update:
 
 The CLI currently covers:
 
-- `auth`: login, status, list, switch, logout, token export.
+- `auth`: login, refresh, status, consent-url, doctor, list, switch, logout, token export.
 - `user`: me, get, list.
 - `config`: init, show, get, set, path, profiles.
 - `team`: list/get/create/update/delete/clone/archive/unarchive/member operations.
@@ -176,6 +176,7 @@ CI runs on GitHub Actions:
 - Microsoft Graph permissions differ by tenant and auth type. A compile-time pass does not prove a command is usable with every auth flow.
 - Webhook subscriptions require an HTTPS public endpoint; `teams listen` only runs the local HTTP listener.
 - Most tests do not hit Microsoft Graph. Add mocked tests for API behavior instead of requiring live credentials.
+- macOS binds keychain access grants to the exact binary signature, so every local build is a "new" application and triggers a fresh keychain prompt when it touches stored tokens. Set `TEAMS_CLI_DISABLE_KEYRING=1` in tests (the CLI test harness already does), and see the macOS keychain section in `docs/troubleshooting.md` for the local re-signing workaround.
 - Keep global option names reserved. In particular, command-specific file paths must not reuse global `--output`, which is the JSON/human/plain output selector.
 - Keep `README.md`, `docs/man/teams.1`, and CLI help in sync. If a documented flag form exists in README, add a CLI regression test for it.
 - When verifying whether a PR is good to merge, check whether it is intended to release. Release automation is version-bump driven: a feature PR without a `Cargo.toml` package version change only runs CI on `main`; a release needs `Cargo.toml` and the root `teams-cli` entry in `Cargo.lock` bumped together, plus a matching `CHANGELOG.md` entry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Project website: [msteamscli.com](http://msteamscli.com/)
 - [Command reference](command-reference.md): practical syntax for every command group.
 - [Examples](examples.md): copyable shell and PowerShell examples for common workflows.
 - [Use cases](use-cases.md): agency, consultancy, enterprise, support, DevOps, and agent patterns.
-- [Troubleshooting](troubleshooting.md): auth, Graph permissions, Windows keyring, rate limits, and stale chats.
+- [Troubleshooting](troubleshooting.md): auth, Graph permissions, macOS keychain prompts, Windows and Linux keyring, rate limits, and stale chats.
 - [FAQ](faq.md): product and auth questions likely to come up during customer rollout.
 - [Release readiness](release-readiness.md): what must pass before internal, RC, and commercial release.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,6 +81,10 @@ In the operating system keyring:
 
 Tokens are not stored in `config.toml`.
 
+On macOS, keychain access grants are tied to the binary's code signature, so
+upgrading or rebuilding `teams` triggers a fresh keychain prompt. See
+[macOS keychain prompts](troubleshooting.md#macos-keychain-prompts).
+
 ## Where is the config file?
 
 ```text

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,45 @@ teams search teams --query "<name>" --output json
 
 Microsoft Graph currently says `/me/joinedTeams` does not support OData query parameters to customize the response. The CLI avoids `$top` for this endpoint.
 
+## macOS keychain prompts
+
+Symptoms:
+
+- macOS asks for the login keychain password when running `teams`, sometimes
+  on every invocation.
+- Clicking "Always Allow" does not stop the prompts.
+- Prompts return after upgrading the CLI or building it from source.
+
+Cause: macOS binds keychain access grants to the exact code signature of the
+binary. The released binaries are ad-hoc signed, so every upgrade produces
+what macOS considers a different application, and a grant made for one build
+does not carry over to the next. Local builds from source each count as
+another distinct application for the same reason. The stored items are
+visible with:
+
+```bash
+security find-generic-password -s teams-cli
+```
+
+Actions:
+
+- Expect one prompt per profile after upgrading or rebuilding; approve it
+  and the grant holds until the binary changes again.
+- To make grants persist across rebuilds, re-sign the binary with a stable
+  local identity: create a self-signed code-signing certificate in Keychain
+  Access (Certificate Assistant, certificate type "Code Signing"), then
+  after each upgrade or build run:
+
+```bash
+codesign --force --sign <certificate-name> --identifier com.osodevops.teams-cli "$(command -v teams)"
+```
+
+- In tests only, set `TEAMS_CLI_DISABLE_KEYRING=1` so the suite never
+  touches the real keychain.
+
+Do not set `TEAMS_CLI_DISABLE_KEYRING=1` for real usage; it prevents token
+storage.
+
 ## Windows keyring issues
 
 Symptoms:


### PR DESCRIPTION
Documentation only. No code changes.

`docs/troubleshooting.md` gains a "macOS keychain prompts" section next to the existing Windows and Linux keyring sections. It explains the cause: macOS binds keychain access grants to the exact code signature of the binary, the released binaries are ad-hoc signed, so every upgrade or source build counts as a different application and prompts again, and "Always Allow" does not carry over. It shows how to inspect the stored items with `security find-generic-password -s teams-cli`, and documents a workaround: re-sign the binary with a stable self-signed code-signing certificate after each upgrade or build.

`AGENTS.md` gets two small updates. The auth command inventory adds `refresh`, `consent-url`, and `doctor`, which shipped in earlier releases but were missing from the list. The development gotchas note that each local build triggers a fresh keychain prompt on macOS for the same signature reason, with a pointer to the new troubleshooting section and to `TEAMS_CLI_DISABLE_KEYRING=1` for tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXWLJ9g87M3GtLSACr2gmi