### PR TITLE
Support editing chat messages with message update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `TEAMS_CLI_PROFILE` environment variable for selecting the credential profile, with the same precedence as other auth environment variables: `--profile` flag, then `TEAMS_CLI_PROFILE`, then the config's `default.profile`, then `default`. This resolves #53.
 - `teams message react` and `teams message unreact` accept `--chat <chat-id>` for one-on-one and group chat messages, as an alternative to the `--team`/`--channel` pair. This resolves #62.
 - `message list` and `message get` now include each message's `reactions` (`reactionType`, `displayName`, `createdDateTime`, `user`).
+- `teams message update` accepts `--chat <chat-id>` to edit one's own chat messages, as an alternative to the `--team`/`--channel` pair.
 
 ### Changed
 
@@ -19,6 +20,7 @@
 - An explicit `--profile default` now addresses the profile named "default" even after `teams auth switch` has set another config default. Previously the flag's default value was indistinguishable from an explicit one, so the switched profile shadowed the literal "default" profile and it became unreachable from the command line. This resolves #55.
 - Token storage no longer deletes and recreates the keyring item on every write. On macOS the recreation discarded the item's access control list, so an "Always Allow" grant was revoked by the next silent token refresh and the keychain prompt returned within the hour. Items are now updated in place, which preserves the grant. This resolves #51.
 - A closed stdout pipe (for example `teams completions bash | head`) no longer panics with exit 101. Stdout writes are centralized in `output::write_stdout` / `write_stdout_line`; a broken pipe is treated as normal early termination (exit 0, nothing on stderr), and a command that fails while its pipe closes still exits with its real error code. This resolves #59.
+- `teams message update` no longer reports "Failed to parse API response" on a successful edit. For delegated callers Microsoft Graph answers the PATCH with `204 No Content` for chat and channel messages alike; the command now sends a no-content PATCH and reads the message back to show the new text. If the read-back fails the command still succeeds and returns `{"id": ..., "updated": true, "readBackError": ...}`.
 - Homebrew publication is now verified end to end: release jobs fail if the tap does not publish all four platform URLs with the release checksums, instead of treating an accepted but unhandled dispatch event as success.
 
 ## v0.3.0 - 2026-07-09

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ teams message list --team <team-id> --channel <channel-id>
 teams message list --chat <chat-id>
 teams message get --team <team-id> --channel <channel-id> --message <msg-id>
 teams message reply --team <team-id> --channel <channel-id> --message <msg-id> --body "Thanks!"
+teams message update --team <team-id> --channel <channel-id> --message <msg-id> --body "Corrected"
+teams message update --chat <chat-id> --message <msg-id> --body "Corrected"
 teams message delete --team <team-id> --channel <channel-id> --message <msg-id>
 teams message react --team <team-id> --channel <channel-id> --message <msg-id> --reaction like
 teams message unreact --team <team-id> --channel <channel-id> --message <msg-id> --reaction like

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -112,7 +112,7 @@ teams message get --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message ME
 teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID)
 teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID [--body TEXT | --stdin] [--content-type text|html] [--image PATH]... [--attach PATH]...
-teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
+teams message update (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
 teams message delete --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
 teams message react (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) --message-id MESSAGE_ID (REACTION | --reaction REACTION)
 teams message unreact (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) --message-id MESSAGE_ID (REACTION | --reaction REACTION)
@@ -123,6 +123,8 @@ teams message unpin --team TEAM_ID --channel CHANNEL_ID (PINNED_MESSAGE_ID | --p
 Normal message mutation requires delegated auth. App-only/client-credentials tokens are rejected for these commands.
 
 `REACTION` is an emoji character or one of the names the CLI translates for you (`like`, `heart`, `laugh`, `surprised`, `sad`, `angry`, `thumbsup`, `thumbsdown`, `eyes`, `tada`, `rocket`, `fire`). Graph only accepts the emoji character on writes.
+
+`message update` edits your own message in place (Graph lets a delegated caller change any property except `policyViolation`); channel edits need the `ChannelMessage.ReadWrite` delegated scope, chat edits need `Chat.ReadWrite`. Graph returns no content on success, so the command reads the message back and prints it; if that read fails the edit has still been applied and the output is `{"id": ..., "updated": true, "readBackError": ...}`.
 
 `--image` sends a picture the way pasting a screenshot does — the bytes travel inside the message itself (a Graph "hosted content"), so it needs no scopes beyond sending messages. `--attach` uploads the file to real storage first (your OneDrive's `Microsoft Teams Chat Files` for chats, the team's SharePoint library for channels) and links it from the message; that upload needs `Files.ReadWrite` (chats) or `Files.ReadWrite.All` (channels). Both flags repeat for multiple files, and `--body` becomes optional when either is present. Inline images are capped at 3MB each; attachments use Graph's 250MB simple-upload limit.
 

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -156,7 +156,7 @@ teams message attachments list (--team TEAM_ID --channel CHANNEL_ID [--reply REP
 teams message attachments download (--team TEAM_ID --channel CHANNEL_ID [--reply REPLY_ID] | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) [--index N] [--dir DIR | --path FILE]
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message-id MESSAGE_ID [--body TEXT | --stdin] [--content-type text|html] [--image PATH]... [--attach PATH]...
 teams message reply --team TEAM_ID --channel CHANNEL_ID --message MESSAGE_ID --body TEXT
-teams message update --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
+teams message update (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) (MESSAGE_ID | --message MESSAGE_ID) --body TEXT [--content-type text|html]
 teams message delete --team TEAM_ID --channel CHANNEL_ID (MESSAGE_ID | --message MESSAGE_ID)
 teams message react (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) --message-id MESSAGE_ID (REACTION | --reaction REACTION)
 teams message unreact (--team TEAM_ID --channel CHANNEL_ID | --chat CHAT_ID) --message-id MESSAGE_ID (REACTION | --reaction REACTION)

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -152,6 +152,22 @@ impl GraphClient {
         .await
     }
 
+    /// PATCH request returning no content.
+    ///
+    /// Some Graph endpoints answer a successful PATCH with an empty body rather
+    /// than the updated resource; editing a chat message is one. Decoding that
+    /// as the resource type reports a parse failure on what was in fact a
+    /// success, so those callers use this and read the resource back instead.
+    pub async fn patch_no_content<B: serde::Serialize>(&self, url: &str, body: &B) -> Result<()> {
+        self.request_with_retry_no_content(|this| {
+            this.http
+                .patch(url)
+                .header("Authorization", this.token.bearer_header())
+                .json(body)
+        })
+        .await
+    }
+
     /// DELETE request returning no content.
     pub async fn delete(&self, url: &str) -> Result<()> {
         self.request_with_retry_no_content(|this| {

--- a/src/api/endpoints.rs
+++ b/src/api/endpoints.rs
@@ -107,7 +107,6 @@ pub fn chat_message_unset_reaction(chat_id: &str, message_id: &str) -> String {
     format!("{GRAPH_V1}/chats/{chat_id}/messages/{message_id}/unsetReaction")
 }
 
-#[allow(dead_code)]
 pub fn chat_message(chat_id: &str, message_id: &str) -> String {
     format!("{GRAPH_V1}/chats/{chat_id}/messages/{message_id}")
 }

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -187,19 +187,30 @@ pub async fn reply_to_message(
         .await
 }
 
+/// Edit a message already sent to a channel, a channel reply, or a chat.
+///
+/// A delegated caller may update every property of a message except
+/// `policyViolation`, so one's own message body can be rewritten in place. An
+/// application-only token is confined to `policyViolation`, which is why the
+/// command layer requires a delegated token first.
+///
+/// For delegated callers Graph answers this PATCH with `204 No Content` on
+/// every target rather than the updated message, so nothing is returned; call
+/// [`get_message`] afterwards to show the new text.
 pub async fn update_message(
     client: &GraphClient,
-    team_id: &str,
-    channel_id: &str,
-    message_id: &str,
+    message: &MessageRef,
     req: &SendMessageRequest,
-) -> Result<ChatMessage> {
-    client
-        .patch(
-            &endpoints::channel_message(team_id, channel_id, message_id),
-            req,
-        )
-        .await
+) -> Result<()> {
+    update_message_at(client, &message.message_url(), req).await
+}
+
+async fn update_message_at(
+    client: &GraphClient,
+    url: &str,
+    req: &SendMessageRequest,
+) -> Result<()> {
+    client.patch_no_content(url, req).await
 }
 
 pub async fn delete_message(
@@ -349,6 +360,7 @@ mod tests {
     use crate::auth::token::TokenInfo;
     use crate::config::NetworkConfig;
     use crate::error::TeamsError;
+    use crate::models::message::ItemBody;
     use reqwest::Client;
     use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -497,5 +509,143 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, TeamsError::PermissionDenied(_)), "{err:?}");
+    }
+
+    fn edit_request() -> SendMessageRequest {
+        SendMessageRequest {
+            body: ItemBody {
+                content_type: Some("text".to_string()),
+                content: Some("corrected text".to_string()),
+            },
+            attachments: None,
+            hosted_contents: None,
+        }
+    }
+
+    #[test]
+    fn chat_message_endpoint_targets_the_chats_collection() {
+        assert_eq!(
+            endpoints::chat_message("19:abc@thread.v2", "1700000000000"),
+            "https://graph.microsoft.com/v1.0/chats/19:abc@thread.v2/messages/1700000000000"
+        );
+    }
+
+    #[test]
+    fn message_ref_update_urls_target_the_message_resource() {
+        let chat = MessageRef::Chat {
+            chat_id: "19:abc@thread.v2".into(),
+            message_id: "1700000000000".into(),
+        };
+        assert_eq!(
+            chat.message_url(),
+            "https://graph.microsoft.com/v1.0/chats/19:abc@thread.v2/messages/1700000000000"
+        );
+        let channel = MessageRef::Channel {
+            team_id: "team-id".into(),
+            channel_id: "channel-id".into(),
+            message_id: "1700000000000".into(),
+        };
+        assert_eq!(
+            channel.message_url(),
+            "https://graph.microsoft.com/v1.0/teams/team-id/channels/channel-id/messages/1700000000000"
+        );
+    }
+
+    /// Graph answers a successful delegated edit with 204 and an empty body,
+    /// for chat messages and channel messages alike.
+    #[tokio::test]
+    async fn update_message_sends_the_body_and_accepts_no_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/chats/chat-id/messages/message-id"))
+            .and(header("authorization", "Bearer test-token"))
+            .and(body_json(serde_json::json!({
+                "body": { "contentType": "text", "content": "corrected text" }
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        update_message_at(
+            &test_client(),
+            &format!("{}/chats/chat-id/messages/message-id", server.uri()),
+            &edit_request(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_channel_message_accepts_no_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/teams/team-id/channels/channel-id/messages/message-id",
+            ))
+            .and(body_json(serde_json::json!({
+                "body": { "contentType": "text", "content": "corrected text" }
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        update_message_at(
+            &test_client(),
+            &format!(
+                "{}/teams/team-id/channels/channel-id/messages/message-id",
+                server.uri()
+            ),
+            &edit_request(),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Editing someone else's message, or one in a chat the caller cannot
+    /// write to, must surface as a permission error rather than a parse error.
+    #[tokio::test]
+    async fn update_message_reports_permission_denied() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "error": { "code": "Forbidden", "message": "Insufficient privileges" }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = update_message_at(
+            &test_client(),
+            &format!("{}/chats/chat-id/messages/message-id", server.uri()),
+            &edit_request(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, TeamsError::PermissionDenied(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn update_message_reports_missing_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "error": { "code": "NotFound", "message": "Message not found" }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = update_message_at(
+            &test_client(),
+            &format!("{}/chats/chat-id/messages/message-id", server.uri()),
+            &edit_request(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, TeamsError::NotFound(_)), "{err:?}");
     }
 }

--- a/src/cli/message.rs
+++ b/src/cli/message.rs
@@ -237,12 +237,15 @@ pub enum MessageCommand {
     },
     /// Update a message
     Update {
-        /// Team ID
-        #[arg(long)]
-        team: String,
-        /// Channel ID
-        #[arg(long)]
-        channel: String,
+        /// Team ID (for channel messages; requires --channel)
+        #[arg(long, requires = "channel", conflicts_with = "chat")]
+        team: Option<String>,
+        /// Channel ID (for channel messages; requires --team)
+        #[arg(long, requires = "team", conflicts_with = "chat")]
+        channel: Option<String>,
+        /// Chat ID (for chat messages)
+        #[arg(long, required_unless_present = "team")]
+        chat: Option<String>,
         /// Message ID
         #[arg(required_unless_present = "message", conflicts_with = "message")]
         message_id: Option<String>,
@@ -563,6 +566,7 @@ pub async fn run(
         MessageCommand::Update {
             team,
             channel,
+            chat,
             message_id,
             message,
             body,
@@ -572,8 +576,37 @@ pub async fn run(
             auth::require_delegated_token(&client.token, "Updating Teams messages")?;
             let message_id = resolve_id(message_id, message, "--message or <MESSAGE_ID>")?;
             let req = build_send_request(body, &content_type, None)?;
-            let msg =
-                api::messages::update_message(&client, &team, &channel, &message_id, &req).await?;
+            let target = if let Some(chat_id) = chat {
+                api::messages::MessageRef::Chat {
+                    chat_id,
+                    message_id: message_id.clone(),
+                }
+            } else {
+                let (team_id, channel_id) = require_channel(team, channel)?;
+                api::messages::MessageRef::Channel {
+                    team_id,
+                    channel_id,
+                    message_id: message_id.clone(),
+                }
+            };
+            api::messages::update_message(&client, &target, &req).await?;
+            // Graph answers a delegated edit with no content, so the message is
+            // fetched back to show the new text. The edit has already been
+            // applied by this point, so a failed read-back is reported alongside
+            // a successful update rather than as a failed command.
+            let msg = match api::messages::get_message(&client, &target).await {
+                Ok(updated) => {
+                    serde_json::to_value(updated).map_err(|e| TeamsError::Other(e.into()))?
+                }
+                Err(err) => {
+                    tracing::warn!("Message updated, but reading it back failed: {err}");
+                    serde_json::json!({
+                        "id": message_id,
+                        "updated": true,
+                        "readBackError": err.to_string(),
+                    })
+                }
+            };
             output::print_success(format, &msg, start);
             Ok(())
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -853,3 +853,57 @@ fn subscribe_unknown_subcommand_fails() {
         .assert()
         .failure();
 }
+
+#[test]
+fn message_update_accepts_chat_target() {
+    teams()
+        .args(["message", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("--chat")
+                .and(predicate::str::contains("for chat messages"))
+                .and(predicate::str::contains("for channel messages")),
+        );
+}
+
+#[test]
+fn message_update_without_a_target_is_rejected() {
+    teams()
+        .args(["message", "update", "1234", "--body", "x"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--chat"));
+}
+
+#[test]
+fn message_update_rejects_mixing_chat_and_channel_targets() {
+    teams()
+        .args([
+            "message",
+            "update",
+            "1234",
+            "--body",
+            "x",
+            "--chat",
+            "19:abc@thread.v2",
+            "--team",
+            "team-id",
+            "--channel",
+            "channel-id",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn message_update_requires_channel_alongside_team() {
+    teams()
+        .args([
+            "message", "update", "1234", "--body", "x", "--team", "team-id",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--channel"));
+}


### PR DESCRIPTION
Adds `--chat` to `message update` so chat messages can be edited. Graph permits this under delegated permissions for any property of one's own message [except `policyViolation`](https://learn.microsoft.com/en-us/graph/api/chatmessage-update).

```bash
teams message update --chat <chat-id> <message-id> --body "Corrected text"
```

`--chat` conflicts with `--team`/`--channel`; one target is required at parse time.

The PATCH returns `204 No Content`, so decoding a `ChatMessage` from it reports a parse failure on a successful edit. This path uses a no-content PATCH and reads the message back; if the read-back fails the command still succeeds, returning `{"updated": true, "readBackError": ...}`.

Wiremock tests cover the PATCH contract and 403/404 mappings; CLI tests cover the target validation. Docs updated.
