### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0 - 2026-08-19
+
 ### Added
 
 - `TEAMS_CLI_PROFILE` environment variable for selecting the credential profile, with the same precedence as other auth environment variables: `--profile` flag, then `TEAMS_CLI_PROFILE`, then the config's `default.profile`, then `default`. This resolves #53.
@@ -14,6 +16,7 @@
 - Browser login now sends `prompt=select_account`, so the identity platform always shows the account picker instead of silently reusing an existing browser session. This makes it possible to sign a second account into another profile with `teams --profile <name> auth login`. This resolves #52.
 - Reactions call the Microsoft Graph v1.0 `setReaction`/`unsetReaction` actions instead of beta.
 - Reaction names are translated to the emoji character Graph requires on writes: the classic `like`, `heart`, `laugh`, `surprised`, `sad`, `angry` (which Graph now rejects by name with HTTP 400) plus `thumbsup`, `thumbsdown`, `eyes`, `tada`, `rocket`, `fire`. Any emoji character passes through unchanged.
+- Refreshed the Rust dependency lockfile (rust-minor group) and bumped `h2` to 0.4.16 for RUSTSEC-2026-0258. GitHub Actions pins updated to `actions/checkout` v7.0.1, `Swatinem/rust-cache` v2.9.2, and `softprops/action-gh-release` v3.0.2.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Releases the reviewed and merged set from #56, #57, #58, #60, #61, #63, #64, plus dependency PRs #49 and #50, as v0.4.0.
- Adds `TEAMS_CLI_PROFILE`, `--chat` support for `message react`/`unreact`/`update`, and `reactions` in message output.
- Changes browser login to `prompt=select_account`; reactions move to Graph v1.0 and translate names to the unicode characters Graph requires on writes.
- Fixes the `--profile default` shadowing bug, keychain item recreation on every token write (macOS "Always Allow" loss), broken-pipe panics, and `message update` parse failures on a successful edit.
- Dependency refresh (rust-minor group) with `h2` 0.4.16 for RUSTSEC-2026-0258; GitHub Actions pins bumped.

## Local verification (macOS, release binary)

- `cargo fmt -- --check`, `cargo check --all-targets --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (152 unit tests, 64 CLI tests)
- `cargo build --release --locked` → `teams 0.4.0`
- `cargo audit` exits 0; one allowed transitive warning remains: RUSTSEC-2026-0097 for `rand` via `reqwest`/`quinn`
- `mandoc -T lint` on all man pages, `git diff --check`

## Live validation (OSO profile, 2026-08-19)

- Read-only: `auth doctor`, `auth status`, `user me`, `team list`, `chat list`, `message list --chat` (reactions field present), `TEAMS_CLI_PROFILE` selection, `completions | head` exits 0 silently.
- Writes in a self-only sandbox chat: `message send --chat`, `message react --chat like` → 👍 "Like", `react eyes` → 👀, `unreact`, `message update --chat` edits and reads back, no beta warning on stderr.
- Keychain item creation date unchanged across a silent token refresh (in-place update).

## Release notes

Feature release (minor bump 0.3.0 → 0.4.0). After merge, `auto-tag.yml` should tag `v0.4.0` and `release.yml` should build all five targets, publish the GitHub Release with checksums, and update the Homebrew tap and Scoop bucket.