### PR TITLE
Report the signed-in user for each profile in auth list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Added
 
 - `presence get` output now includes `statusMessage.publishedDateTime`, a documented Graph property that was previously discarded during deserialization.
-- `teams auth list` reports, for each profile, the signed-in `user`, `tenant_id`, and `auth_type` (`delegated`, `app-only`, or `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`, without any network call. A profile whose token cannot be read is still listed with those fields `null`; one whose token cannot be decoded keeps its `expires_at` and has the claim-derived fields `null`. This resolves #54.
+- `teams auth list` reports, for each profile, the signed-in `user`, `tenant_id`, and `auth_type` (`delegated`, `app-only`, or `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`, without any network call. A profile whose token cannot be read or decoded is still listed with those fields `null`. This resolves #54.
 
 ## v0.4.0 - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Added
 
 - `presence get` output now includes `statusMessage.publishedDateTime`, a documented Graph property that was previously discarded during deserialization.
+- `teams auth list` reports, for each profile, the signed-in `user`, `tenant_id`, and `auth_type` (`delegated`, `app-only`, or `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`, without any network call. A profile whose token cannot be read is still listed with those fields `null`; one whose token cannot be decoded keeps its `expires_at` and has the claim-derived fields `null`. This resolves #54.
 
 ## v0.4.0 - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- `teams auth list` now emits `profiles` as an array of objects rather than an array of profile-name strings. A consumer reading `.data.profiles[]` as a string needs `.data.profiles[].name` instead. On a terminal the command prints a table, with the active profile marked `*`, in place of the raw JSON it used to show.
 - `teams presence set --expiration` is now checked before the request is sent. Microsoft Graph accepts an ISO 8601 duration from `PT5M` to `PT4H`; a malformed or out-of-range value now fails as invalid input (exit 2) with the bounds in the message, instead of costing a round trip and returning a 400 to interpret. The `--availability` and `--activity` help text now names the five pairs `setPresence` actually accepts, rather than `Offline` and `InAMeeting`, which only occur when reading a presence. This resolves #81.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ teams auth refresh           # Silently redeem the refresh token (picks up newly
 teams auth status            # Check if session is valid (exit code 0/1)
 teams auth consent-url       # Print admin consent URL for the active auth app
 teams auth doctor            # Diagnose config and token state
-teams auth list              # List authenticated profiles
+teams auth list              # List profiles and the account each one holds
 teams auth switch <profile>  # Switch active profile
 teams auth logout            # Clear stored credentials
 teams auth token             # Export access token to stdout

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -291,11 +291,37 @@ Check whether the profile is authenticated:
 teams auth status --output json
 ```
 
-List profiles:
+List profiles and the account each one holds:
 
 ```bash
 teams auth list --output json
 ```
+
+Each entry reports the signed-in `user` (principal name), `tenant_id`, and
+`auth_type` (`delegated`, `app-only`, or `unknown`), decoded from the stored
+token's claims, plus the stored token's `expires_at`. No network call is made
+and no refresh is attempted, so `expires_at` may be in the past. A profile
+whose token cannot be read from the keyring is still listed with all four
+fields `null`; one whose token is stored but cannot be decoded keeps its
+`expires_at` and has the three claim-derived fields `null`. An `app-only`
+profile has no `user`.
+
+```json
+{
+  "success": true,
+  "data": {
+    "profiles": [
+      { "name": "default", "user": "a@contoso.com", "tenant_id": "...", "auth_type": "delegated", "expires_at": "..." },
+      { "name": "alt", "user": "b@contoso.com", "tenant_id": "...", "auth_type": "delegated", "expires_at": "..." }
+    ],
+    "active": "default"
+  },
+  "metadata": { "request_id": "...", "timestamp": "...", "api_version": "v1.0", "duration_ms": 12 }
+}
+```
+
+On macOS this reads one keychain item per profile, so the first run of a new
+binary may prompt once per profile.
 
 Log out:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -301,9 +301,8 @@ Each entry reports the signed-in `user` (principal name), `tenant_id`, and
 `auth_type` (`delegated`, `app-only`, or `unknown`), decoded from the stored
 token's claims, plus the stored token's `expires_at`. No network call is made
 and no refresh is attempted, so `expires_at` may be in the past. A profile
-whose token cannot be read from the keyring is still listed with all four
-fields `null`; one whose token is stored but cannot be decoded keeps its
-`expires_at` and has the three claim-derived fields `null`. An `app-only`
+whose token cannot be read or decoded is still listed with all four fields
+`null`, so a broken keyring entry does not hide the profile. An `app-only`
 profile has no `user`.
 
 ```json

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -319,6 +319,18 @@ profile has no `user`.
 }
 ```
 
+On a terminal the same information is printed as a table, with the active
+profile marked `*`:
+
+```text
+  Profile   User             Tenant ID   Auth        Expires
+* default   a@contoso.com    ...         delegated   ...
+  alt       b@contoso.com    ...         delegated   ...
+```
+
+Note that `profiles` is an array of objects; a consumer that read it as an
+array of names needs `.data.profiles[].name`.
+
 On macOS this reads one keychain item per profile, so the first run of a new
 binary may prompt once per profile.
 

--- a/src/auth/token.rs
+++ b/src/auth/token.rs
@@ -46,6 +46,14 @@ pub struct TokenClaims {
 }
 
 impl TokenClaims {
+    /// The signed-in user's principal name, when the token carries one.
+    ///
+    /// Delegated tokens carry `preferred_username`; older tokens carry only
+    /// `upn`. App-only tokens carry neither.
+    pub fn user(&self) -> Option<&str> {
+        self.preferred_username.as_deref().or(self.upn.as_deref())
+    }
+
     pub fn auth_type(&self) -> &'static str {
         if self.scp.as_deref().is_some_and(|s| !s.trim().is_empty()) {
             "delegated"

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -170,16 +170,16 @@ fn annotate_consent_error(
 ///
 /// The identity comes from the access token's unverified claims, the same
 /// source `auth status` and `auth doctor` use. A profile whose token cannot be
-/// read or decoded is still listed, with the identity fields null, so a broken
-/// keyring entry does not hide the profile.
+/// read or decoded is still listed, with every field but `name` null, so a
+/// broken keyring entry does not hide the profile.
 fn summarize_profile(name: &str, token: Option<&auth::token::TokenInfo>) -> serde_json::Value {
-    let claims = token.and_then(|t| t.unverified_claims());
+    let decoded = token.and_then(|t| t.unverified_claims().map(|claims| (t, claims)));
     serde_json::json!({
         "name": name,
-        "user": claims.as_ref().and_then(|c| c.user()),
-        "tenant_id": claims.as_ref().and_then(|c| c.tid.as_deref()),
-        "auth_type": claims.as_ref().map(|c| c.auth_type()),
-        "expires_at": token.and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),
+        "user": decoded.as_ref().and_then(|(_, c)| c.user()),
+        "tenant_id": decoded.as_ref().and_then(|(_, c)| c.tid.as_deref()),
+        "auth_type": decoded.as_ref().map(|(_, c)| c.auth_type()),
+        "expires_at": decoded.as_ref().and_then(|(t, _)| t.expires_at.map(|e| e.to_rfc3339())),
     })
 }
 
@@ -530,16 +530,17 @@ mod tests {
     }
 
     #[test]
-    fn summarize_profile_keeps_expiry_when_token_is_not_a_jwt() {
+    fn summarize_profile_nulls_every_field_when_token_is_not_a_jwt() {
         let mut token = token_with_payload(serde_json::json!({}));
         token.access_token = "opaque-token".into();
 
         let summary = summarize_profile("opaque", Some(&token));
 
+        assert_eq!(summary["name"], "opaque");
         assert!(summary["user"].is_null());
         assert!(summary["tenant_id"].is_null());
         assert!(summary["auth_type"].is_null());
-        assert_eq!(summary["expires_at"], "2030-01-02T03:04:05+00:00");
+        assert!(summary["expires_at"].is_null());
     }
 
     #[test]

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -66,7 +66,7 @@ pub enum AuthCommand {
         #[arg(long, env = "TEAMS_CLI_TENANT_ID")]
         tenant_id: Option<String>,
     },
-    /// List all authenticated profiles
+    /// List stored profiles and the account each one holds
     List,
     /// Switch active profile
     Switch {
@@ -164,6 +164,23 @@ fn annotate_consent_error(
         }
         other => other,
     }
+}
+
+/// Describe one stored profile for `auth list` without touching the network.
+///
+/// The identity comes from the access token's unverified claims, the same
+/// source `auth status` and `auth doctor` use. A profile whose token cannot be
+/// read or decoded is still listed, with the identity fields null, so a broken
+/// keyring entry does not hide the profile.
+fn summarize_profile(name: &str, token: Option<&auth::token::TokenInfo>) -> serde_json::Value {
+    let claims = token.and_then(|t| t.unverified_claims());
+    serde_json::json!({
+        "name": name,
+        "user": claims.as_ref().and_then(|c| c.user()),
+        "tenant_id": claims.as_ref().and_then(|c| c.tid.as_deref()),
+        "auth_type": claims.as_ref().map(|c| c.auth_type()),
+        "expires_at": token.and_then(|t| t.expires_at.map(|e| e.to_rfc3339())),
+    })
 }
 
 fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
@@ -333,7 +350,7 @@ pub async fn run(
                     "is_graph_audience": claims.as_ref().and_then(|c| c.is_graph_audience()),
                     "tenant_id": claims.as_ref().and_then(|c| c.tid.clone()),
                     "app_id": claims.as_ref().and_then(|c| c.appid.clone()).or_else(|| claims.as_ref().and_then(|c| c.azp.clone())),
-                    "user": claims.as_ref().and_then(|c| c.preferred_username.clone()).or_else(|| claims.as_ref().and_then(|c| c.upn.clone())),
+                    "user": claims.as_ref().and_then(|c| c.user()),
                 })),
             });
             output::print_success(format, &msg, start);
@@ -369,7 +386,10 @@ pub async fn run(
 
         AuthCommand::List => {
             let start = Instant::now();
-            let profiles = auth::keyring::list_profiles();
+            let profiles: Vec<serde_json::Value> = auth::keyring::list_profiles()
+                .iter()
+                .map(|name| summarize_profile(name, auth::keyring::get_token(name).ok().as_ref()))
+                .collect();
             let msg = serde_json::json!({
                 "profiles": profiles,
                 "active": profile,
@@ -454,6 +474,73 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use chrono::{TimeZone, Utc};
+
+    fn token_with_payload(payload: serde_json::Value) -> auth::token::TokenInfo {
+        auth::token::TokenInfo {
+            access_token: format!(
+                "header.{}.signature",
+                URL_SAFE_NO_PAD.encode(payload.to_string())
+            ),
+            expires_at: Some(Utc.with_ymd_and_hms(2030, 1, 2, 3, 4, 5).unwrap()),
+            token_type: "Bearer".into(),
+            scope: None,
+            refresh_token: None,
+            profile: "work".into(),
+        }
+    }
+
+    #[test]
+    fn summarize_profile_reports_identity_from_token_claims() {
+        let token = token_with_payload(serde_json::json!({
+            "preferred_username": "a@contoso.com",
+            "tid": "tenant-1",
+            "scp": "User.Read",
+        }));
+
+        let summary = summarize_profile("work", Some(&token));
+
+        assert_eq!(summary["name"], "work");
+        assert_eq!(summary["user"], "a@contoso.com");
+        assert_eq!(summary["tenant_id"], "tenant-1");
+        assert_eq!(summary["auth_type"], "delegated");
+        assert_eq!(summary["expires_at"], "2030-01-02T03:04:05+00:00");
+    }
+
+    #[test]
+    fn summarize_profile_falls_back_to_upn_for_user() {
+        let token = token_with_payload(serde_json::json!({ "upn": "b@contoso.com" }));
+
+        assert_eq!(
+            summarize_profile("alt", Some(&token))["user"],
+            "b@contoso.com"
+        );
+    }
+
+    #[test]
+    fn summarize_profile_lists_profile_without_token_with_null_fields() {
+        let summary = summarize_profile("broken", None);
+
+        assert_eq!(summary["name"], "broken");
+        assert!(summary["user"].is_null());
+        assert!(summary["tenant_id"].is_null());
+        assert!(summary["auth_type"].is_null());
+        assert!(summary["expires_at"].is_null());
+    }
+
+    #[test]
+    fn summarize_profile_keeps_expiry_when_token_is_not_a_jwt() {
+        let mut token = token_with_payload(serde_json::json!({}));
+        token.access_token = "opaque-token".into();
+
+        let summary = summarize_profile("opaque", Some(&token));
+
+        assert!(summary["user"].is_null());
+        assert!(summary["tenant_id"].is_null());
+        assert!(summary["auth_type"].is_null());
+        assert_eq!(summary["expires_at"], "2030-01-02T03:04:05+00:00");
+    }
 
     #[test]
     fn annotate_consent_error_adds_guidance_with_requested_scopes() {

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -183,6 +183,26 @@ fn summarize_profile(name: &str, token: Option<&auth::token::TokenInfo>) -> serd
     })
 }
 
+/// One `auth list` table row. Telling which profile is the active one is half of
+/// what the command is for, so the active name carries a marker; a field the token
+/// did not yield is left blank rather than printed as the word "null".
+fn profile_row(summary: &serde_json::Value, active: &str) -> Vec<String> {
+    let field = |key: &str| summary[key].as_str().unwrap_or_default().to_string();
+    let name = field("name");
+    let marked = if name == active {
+        format!("* {name}")
+    } else {
+        format!("  {name}")
+    };
+    vec![
+        marked,
+        field("user"),
+        field("tenant_id"),
+        field("auth_type"),
+        field("expires_at"),
+    ]
+}
+
 fn delegated_admin_consent_url(client_id: &str, tenant_id: &str, delegated_scopes: &str) -> String {
     let scopes = graph_admin_consent_scopes(delegated_scopes);
     format!(
@@ -394,7 +414,14 @@ pub async fn run(
                 "profiles": profiles,
                 "active": profile,
             });
-            output::print_success(format, &msg, start);
+            if format == OutputFormat::Human {
+                let headers = vec!["Profile", "User", "Tenant ID", "Auth", "Expires"];
+                let rows: Vec<Vec<String>> =
+                    profiles.iter().map(|p| profile_row(p, profile)).collect();
+                output::table::print_table(headers, rows);
+            } else {
+                output::print_success(format, &msg, start);
+            }
             Ok(())
         }
 
@@ -541,6 +568,42 @@ mod tests {
         assert!(summary["tenant_id"].is_null());
         assert!(summary["auth_type"].is_null());
         assert!(summary["expires_at"].is_null());
+    }
+
+    #[test]
+    fn profile_row_marks_the_active_profile_and_blanks_missing_fields() {
+        let token = token_with_payload(serde_json::json!({
+            "preferred_username": "a@contoso.com",
+            "tid": "tenant-1",
+            "scp": "User.Read",
+        }));
+        let active = summarize_profile("work", Some(&token));
+        assert_eq!(
+            profile_row(&active, "work"),
+            vec![
+                "* work".to_string(),
+                "a@contoso.com".to_string(),
+                "tenant-1".to_string(),
+                "delegated".to_string(),
+                "2030-01-02T03:04:05+00:00".to_string(),
+            ]
+        );
+
+        // a profile that is not the active one is indented to the same width
+        assert_eq!(profile_row(&active, "other")[0], "  work");
+
+        // a profile whose token could not be read prints blanks, not the word "null"
+        let broken = summarize_profile("broken", None);
+        assert_eq!(
+            profile_row(&broken, "work"),
+            vec![
+                "  broken".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ]
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -111,6 +111,18 @@ fn auth_status_without_login_exits_nonzero() {
 }
 
 #[test]
+fn auth_list_without_keyring_reports_no_profiles() {
+    teams()
+        .args(["auth", "list", "--output", "json"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("\"profiles\": []")
+                .and(predicate::str::contains("\"active\": \"default\"")),
+        );
+}
+
+#[test]
 fn auth_consent_url_uses_oso_default_client_id() {
     teams()
         .args(["auth", "consent-url", "--output", "json"])


### PR DESCRIPTION
Resolves #54.

`teams auth list` printed only profile names, so with more than one profile there was no way to tell which account each held without running `auth status` per profile.

Each entry now carries the signed-in `user` (principal name), `tenant_id`, and `auth_type` (`delegated` / `app-only` / `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`. No network call is made and no refresh is attempted. A profile whose token cannot be read or decoded is still listed with all four fields `null`, so a broken keyring entry does not hide the profile.

The `data` payload of the JSON envelope:

```json
{
  "profiles": [
    { "name": "default", "user": "a@contoso.com", "tenant_id": "...", "auth_type": "delegated", "expires_at": "..." },
    { "name": "alt", "user": "b@contoso.com", "tenant_id": "...", "auth_type": "delegated", "expires_at": "..." }
  ],
  "active": "default"
}
```

`auth_type` is included beyond the issue's field list because an app-only profile legitimately has no `user`, and without it such a profile is indistinguishable from a broken one.

The principal-name lookup (`preferred_username`, then `upn`) moves into `TokenClaims::user` and the login handler reuses it.

Tests: four unit tests on the per-profile summary (full claims, `upn` fallback, no token, opaque non-JWT token) and a CLI test for the keyring-disabled case. Live-verified against two real profiles on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKmZeGMitqEQ7Lhg9AkWkn
