### PR TITLE
Fix the presence write commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- `teams presence set`, `presence status` and `presence clear` now work with a default delegated login. All three Graph calls require `Presence.ReadWrite`, which the built-in scope set did not request, so every presence write returned 403. Microsoft does not mark that delegated scope admin-consent required, so it joins the defaults. An existing session keeps the scopes it was granted — run `teams auth login` again to consent to the new one. This resolves #70.
+- `teams presence clear` no longer fails with `The SessionId field is required`, and `presence set` no longer opens a presence session under a fresh random UUID that nothing could later clear. Graph keys a presence session to the application that owns it, so both commands now send that application's ID as `sessionId` — a configured `client_id` when there is one, otherwise the `azp`/`appid` claim of the token itself — and report it back. Graph's 404 for "no such session" is reported as `no_presence_session` rather than an error, so a second clear or a retry after a lost response succeeds. This resolves #71.
+- The presence write commands now reject an app-only token locally, as the message write commands already did, instead of sending a request that cannot succeed against `/me`.
 - `teams presence get` no longer fails with `API error (200): Failed to parse API response` when the target's Teams status message carries an expiry. Microsoft Graph sends `statusMessage.expiryDateTime` as a `dateTimeTimeZone` object, not a string, so both `GET /me/presence` and `GET /users/{id}/presence` failed to deserialize for any account with an expiring status message. This resolves #69.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -425,6 +425,15 @@ teams presence clear
 teams presence status --message "In deep focus" [--expiry <datetime>]
 ```
 
+Graph keys a presence session to the application that opened it. `set` and
+`clear` send that application's ID as the session ID — a configured
+`client_id`, or the one the access token was issued to — and report it back, so
+a `clear` run under different configuration than the `set` is visible. `clear`
+succeeds either way and reports what Graph answered: `presence_cleared` when it
+closed a session, `no_presence_session` when it knew of none under that ID —
+which is also what a retry sees when the attempt before it succeeded but its
+response was lost.
+
 ### Search
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ and presence scopes. It intentionally does not request
 admin-consent required. Use `--scopes` or a customer-owned app when a workflow
 needs channel message reads.
 
+A session created before a scope was added to this default set keeps the
+scopes it was granted. Run `teams auth login` again to consent to a newly
+added one.
+
 **Credential resolution order**: CLI flags > environment variables > config file profiles.
 
 Delegated scope resolution follows the same order: `--scopes` (or

--- a/README.md
+++ b/README.md
@@ -232,7 +232,11 @@ needs channel message reads.
 
 A session created before a scope was added to this default set keeps the
 scopes it was granted. Run `teams auth login` again to consent to a newly
-added one.
+added one. A login that names its own scopes replaces the default set rather
+than extending it, so `--scopes`, `TEAMS_CLI_SCOPES` and a profile's `scopes`
+field do not pick up additions on their own — restate the whole list with the
+new scope in it. `Presence.ReadWrite`, which the presence write commands need,
+joined the defaults in this way.
 
 **Credential resolution order**: CLI flags > environment variables > config file profiles.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -180,6 +180,22 @@ identity platform rejects the whole request (AADSTS65001) rather than issuing
 a narrower token; the CLI then prints the exact `consent-url` command to
 grant it, or fall back to `teams auth login` for interactive consent.
 
+Re-login picks up a scope added to the default set only where consent for it
+can actually be given. The identity platform accepts scopes at authorize time
+that a registration does not list statically — dynamic consent — but a tenant
+that reserves consent to an administrator rejects the login instead, and
+re-running `teams auth login` will not change that. `teams auth consent-url`
+is the route in that case: it builds an admin-consent URL for the scopes the
+profile resolves to, dynamic ones included, so the permission does not have to
+be added to the registration first. Adding it statically is what portal
+consent and `.default` require, and it remains the tidier arrangement for a
+registration you own.
+
+The practical consequence for anyone authenticating through their own
+registration rather than the built-in one: a newly added default scope such as
+`Presence.ReadWrite` may need an administrator to grant it before any session
+carries it, however many times you log in.
+
 Customer-owned delegated app:
 
 ```bash

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -149,7 +149,9 @@ scopes = "User.Read Chat.ReadWrite ChatMessage.Send People.Read offline_access"
 
 The profile `scopes` value replaces the default delegated scope string (it is
 not additive); `offline_access` is appended when missing so refresh tokens
-keep working. Resolution order is `--scopes` or `TEAMS_CLI_SCOPES`, then the
+keep working. Because it is a replacement, a profile that pins its own scopes
+keeps requesting exactly those when a scope is added to the default set, and
+has to restate the list to pick the new one up. Resolution order is `--scopes` or `TEAMS_CLI_SCOPES`, then the
 profile `scopes` field, then the default scope set. `teams auth consent-url`
 and `teams auth doctor` reflect the profile's resolved scopes, so admin
 consent links match what login will request. The default scope set remains

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -72,7 +72,7 @@ Use a concrete tenant ID or verified tenant domain for customer onboarding. `org
 
 ## Current delegated permissions
 
-The OSO app registration currently asks for these delegated Microsoft Graph permissions:
+Default delegated login requests these Microsoft Graph permissions:
 
 ```text
 User.Read
@@ -85,9 +85,10 @@ ChatMessage.Send
 ChatMessage.Read
 User.ReadBasic.All
 Presence.Read.All
+Presence.ReadWrite
 ```
 
-These permissions cover the current chat read/write, channel-send, team/channel discovery, user lookup, and presence smoke tests. The default does not include `ChannelMessage.Read.All` because Microsoft marks that delegated Graph scope as admin-consent required. Add it explicitly when a workflow needs channel message reads:
+These permissions cover the current chat read/write, channel-send, team/channel discovery, user lookup, and presence reads and writes. `Presence.ReadWrite` is what `presence set`, `presence status` and `presence clear` require; Microsoft does not mark it admin-consent required. The default does not include `ChannelMessage.Read.All` because Microsoft marks that delegated Graph scope as admin-consent required. Add it explicitly when a workflow needs channel message reads:
 
 ```bash
 teams auth login --device-code --scopes "User.Read ChannelMessage.Read.All offline_access"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,6 +49,7 @@ ChatMessage.Send
 ChatMessage.Read
 User.ReadBasic.All
 Presence.Read.All
+Presence.ReadWrite
 ```
 
 The default avoids `ChannelMessage.Read.All` because Microsoft marks that delegated Graph scope as admin-consent required. Customers that need channel message reads should grant it explicitly with `--scopes` or through a customer-owned app. Future features may require additional permissions.

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Result, TeamsError};
 use crate::models::common::PageResponse;
 use crate::models::presence::{
     ClearPresenceRequest, GetPresenceBatchRequest, Presence, SetPresenceRequest,
@@ -34,16 +34,27 @@ async fn set_presence_at(client: &GraphClient, url: &str, req: &SetPresenceReque
     client.post_no_content(url, req).await
 }
 
-pub async fn clear_presence(client: &GraphClient, req: &ClearPresenceRequest) -> Result<()> {
+pub async fn clear_presence(client: &GraphClient, req: &ClearPresenceRequest) -> Result<bool> {
     clear_presence_at(client, &endpoints::clear_presence(), req).await
 }
 
+/// Graph answers 404 when the application has no presence session to clear, which is the state
+/// `clear` exists to reach; reporting it as a miss would make a second clear, or a retry after
+/// an ambiguous response, fail against presence that is already automatic. It is not the same
+/// outcome as clearing a live session, though — a session opened under a different application
+/// ID answers the same way — so the caller is told which of the two Graph reported. `true` means
+/// Graph cleared a session; `false` that it knew of none under this `sessionId`, which is also
+/// what a retry sees when the attempt before it succeeded but its response was lost.
 async fn clear_presence_at(
     client: &GraphClient,
     url: &str,
     req: &ClearPresenceRequest,
-) -> Result<()> {
-    client.post_no_content(url, req).await
+) -> Result<bool> {
+    match client.post_no_content(url, req).await {
+        Ok(()) => Ok(true),
+        Err(TeamsError::NotFound(_)) => Ok(false),
+        Err(err) => Err(err),
+    }
 }
 
 pub async fn set_status_message(client: &GraphClient, req: &SetStatusMessageRequest) -> Result<()> {
@@ -141,7 +152,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        clear_presence_at(
+        let cleared = clear_presence_at(
             &test_client(),
             &format!("{}/me/presence/clearPresence", server.uri()),
             &ClearPresenceRequest {
@@ -150,6 +161,62 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(cleared);
+    }
+
+    #[tokio::test]
+    async fn clear_presence_treats_a_missing_session_as_already_cleared() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/me/presence/clearPresence"))
+            .respond_with(ResponseTemplate::new(404).set_body_string(
+                r#"{"error":{"code":"NotFound","message":"Presence session not found."}}"#,
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cleared = clear_presence_at(
+            &test_client(),
+            &format!("{}/me/presence/clearPresence", server.uri()),
+            &ClearPresenceRequest {
+                session_id: "app-id".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!cleared);
+    }
+
+    #[tokio::test]
+    async fn clear_presence_reports_no_session_when_a_retry_follows_a_lost_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/me/presence/clearPresence"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/me/presence/clearPresence"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = test_client();
+        client.network.max_retries = 1;
+        let cleared = clear_presence_at(
+            &client,
+            &format!("{}/me/presence/clearPresence", server.uri()),
+            &ClearPresenceRequest {
+                session_id: "app-id".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!cleared);
     }
 
     #[tokio::test]

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -1,7 +1,8 @@
 use crate::error::Result;
 use crate::models::common::PageResponse;
 use crate::models::presence::{
-    GetPresenceBatchRequest, Presence, SetPresenceRequest, SetStatusMessageRequest,
+    ClearPresenceRequest, GetPresenceBatchRequest, Presence, SetPresenceRequest,
+    SetStatusMessageRequest,
 };
 
 use super::client::GraphClient;
@@ -26,15 +27,23 @@ pub async fn get_presence_batch(client: &GraphClient, ids: Vec<String>) -> Resul
 }
 
 pub async fn set_presence(client: &GraphClient, req: &SetPresenceRequest) -> Result<()> {
-    client
-        .post_no_content(&endpoints::set_presence(), req)
-        .await
+    set_presence_at(client, &endpoints::set_presence(), req).await
 }
 
-pub async fn clear_presence(client: &GraphClient) -> Result<()> {
-    client
-        .post_no_content(&endpoints::clear_presence(), &serde_json::json!({}))
-        .await
+async fn set_presence_at(client: &GraphClient, url: &str, req: &SetPresenceRequest) -> Result<()> {
+    client.post_no_content(url, req).await
+}
+
+pub async fn clear_presence(client: &GraphClient, req: &ClearPresenceRequest) -> Result<()> {
+    clear_presence_at(client, &endpoints::clear_presence(), req).await
+}
+
+async fn clear_presence_at(
+    client: &GraphClient,
+    url: &str,
+    req: &ClearPresenceRequest,
+) -> Result<()> {
+    client.post_no_content(url, req).await
 }
 
 pub async fn set_status_message(client: &GraphClient, req: &SetStatusMessageRequest) -> Result<()> {
@@ -44,12 +53,12 @@ pub async fn set_status_message(client: &GraphClient, req: &SetStatusMessageRequ
 }
 
 #[cfg(test)]
-mod expiry_tests {
+mod tests {
     use super::*;
     use crate::auth::token::TokenInfo;
     use crate::config::NetworkConfig;
     use reqwest::Client;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client() -> GraphClient {
@@ -119,5 +128,57 @@ mod expiry_tests {
             Some("2026-09-01T08:00:00.0000000")
         );
         assert_eq!(expiry.time_zone.as_deref(), Some("UTC"));
+    }
+
+    #[tokio::test]
+    async fn clear_presence_sends_the_session_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/me/presence/clearPresence"))
+            .and(body_json(serde_json::json!({ "sessionId": "app-id" })))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        clear_presence_at(
+            &test_client(),
+            &format!("{}/me/presence/clearPresence", server.uri()),
+            &ClearPresenceRequest {
+                session_id: "app-id".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_presence_sends_the_session_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/me/presence/setPresence"))
+            .and(body_json(serde_json::json!({
+                "sessionId": "app-id",
+                "availability": "Available",
+                "activity": "Available",
+                "expirationDuration": "PT1H"
+            })))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        set_presence_at(
+            &test_client(),
+            &format!("{}/me/presence/setPresence", server.uri()),
+            &SetPresenceRequest {
+                session_id: "app-id".to_string(),
+                availability: "Available".to_string(),
+                activity: "Available".to_string(),
+                expiration_duration: Some("PT1H".to_string()),
+            },
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -183,7 +183,7 @@ pub fn require_delegated_token(token: &TokenInfo, operation: &str) -> Result<()>
     if let Some(claims) = token.unverified_claims() {
         if claims.auth_type() == "app-only" {
             return Err(TeamsError::PermissionDenied(format!(
-                "{operation} requires delegated Microsoft Graph auth. App-only/client-credentials tokens cannot send normal live Teams chat or channel messages; use `teams auth login --device-code` or future bot mode."
+                "{operation} requires delegated Microsoft Graph auth. App-only/client-credentials tokens act without a signed-in user, so they cannot carry out an action Teams attributes to one; use `teams auth login --device-code` or future bot mode."
             )));
         }
     }
@@ -208,6 +208,42 @@ mod tests {
             refresh_token: refresh_token.map(|s| s.to_string()),
             profile: "default".into(),
         }
+    }
+
+    #[test]
+    fn delegated_guard_rejects_an_app_only_token() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let mut token = token_with(None, None, None);
+        token.access_token = format!(
+            "header.{}.signature",
+            URL_SAFE_NO_PAD
+                .encode(serde_json::json!({ "roles": ["Presence.ReadWrite.All"] }).to_string())
+        );
+        let err = require_delegated_token(&token, "Setting your Teams presence").unwrap_err();
+        assert!(matches!(err, TeamsError::PermissionDenied(_)));
+        let message = err.to_string();
+        assert!(message.contains("Setting your Teams presence"));
+        // the shared message is reached by presence as well as messages, so it must not
+        // claim the caller was trying to send a chat message
+        assert!(!message.contains("chat or channel messages"));
+    }
+
+    #[test]
+    fn delegated_guard_admits_a_delegated_token() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let mut token = token_with(None, None, None);
+        token.access_token = format!(
+            "header.{}.signature",
+            URL_SAFE_NO_PAD.encode(serde_json::json!({ "scp": "Presence.ReadWrite" }).to_string())
+        );
+        assert!(require_delegated_token(&token, "Setting your Teams presence").is_ok());
+    }
+
+    #[test]
+    fn delegated_guard_admits_an_opaque_token() {
+        // an opaque token yields no claims; the guard must not block on a guess
+        let token = token_with(None, None, None);
+        assert!(require_delegated_token(&token, "Setting your Teams presence").is_ok());
     }
 
     #[test]

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -127,6 +127,7 @@ pub async fn run(
             activity,
             expiration,
         } => {
+            auth::require_delegated_token(&client.token, "Setting your Teams presence")?;
             let start = Instant::now();
             let req = SetPresenceRequest {
                 session_id: presence_session_id(
@@ -148,6 +149,7 @@ pub async fn run(
         }
 
         PresenceCommand::Status { message, expiry } => {
+            auth::require_delegated_token(&client.token, "Setting your Teams status message")?;
             let start = Instant::now();
             let req = SetStatusMessageRequest {
                 status_message: SetStatusMessageBody {
@@ -168,6 +170,7 @@ pub async fn run(
         }
 
         PresenceCommand::Clear => {
+            auth::require_delegated_token(&client.token, "Clearing your Teams presence")?;
             let start = Instant::now();
             let req = ClearPresenceRequest {
                 session_id: presence_session_id(

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crate::api::{self, GraphClient};
 use crate::auth;
 use crate::auth::token::TokenInfo;
-use crate::config::ConfigFile;
+use crate::config::{self, ConfigFile};
 use crate::error::{Result, TeamsError};
 use crate::models::presence::{
     ClearPresenceRequest, DateTimeTimeZone, SetPresenceRequest, SetStatusMessageBody,
@@ -129,7 +129,10 @@ pub async fn run(
         } => {
             let start = Instant::now();
             let req = SetPresenceRequest {
-                session_id: presence_session_id(&client.token)?,
+                session_id: presence_session_id(
+                    &client.token,
+                    config::resolve_client_id(None, profile, config),
+                )?,
                 availability,
                 activity,
                 expiration_duration: expiration,
@@ -163,7 +166,10 @@ pub async fn run(
         PresenceCommand::Clear => {
             let start = Instant::now();
             let req = ClearPresenceRequest {
-                session_id: presence_session_id(&client.token)?,
+                session_id: presence_session_id(
+                    &client.token,
+                    config::resolve_client_id(None, profile, config),
+                )?,
             };
             api::presence::clear_presence(&client, &req).await?;
             let result = serde_json::json!({"status": "presence_cleared"});
@@ -174,10 +180,19 @@ pub async fn run(
 }
 
 /// Graph identifies a presence session by the application that owns it and expects that
-/// application's ID as `sessionId`. Reading it from the token's own claims keeps `set` and
-/// `clear` on one session regardless of what the profile's configured client ID says now,
-/// and works for a token supplied through `TEAMS_CLI_ACCESS_TOKEN`.
-fn presence_session_id(token: &TokenInfo) -> Result<String> {
+/// application's ID as `sessionId`. A configured client ID names that application directly and
+/// wins, because Microsoft asks callers to treat access tokens as opaque and a Graph token is
+/// not guaranteed to be a readable JSON Web Token. Logins through the built-in application
+/// configure no client ID, so the token's own `azp` or `appid` claim stands in. `set` and
+/// `clear` agree either way, because both resolve the value the same way.
+fn presence_session_id(token: &TokenInfo, configured_client_id: Option<String>) -> Result<String> {
+    let configured = configured_client_id
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
+    if let Some(client_id) = configured {
+        return Ok(client_id);
+    }
+
     token
         .unverified_claims()
         .and_then(|claims| {
@@ -188,9 +203,11 @@ fn presence_session_id(token: &TokenInfo) -> Result<String> {
         })
         .ok_or_else(|| {
             TeamsError::AuthError(
-                "Access token carries no application ID claim (azp or appid), which Graph \
-                 requires as the presence sessionId. Sign in again with `teams auth login`, or \
-                 check the token in TEAMS_CLI_ACCESS_TOKEN if that is set."
+                "No application ID is available for the presence sessionId, which Graph \
+                 requires: the access token carries no readable azp or appid claim, and no \
+                 client ID is configured. Set TEAMS_CLI_CLIENT_ID or the profile's client_id \
+                 to the application the token was issued to, or sign in again with `teams auth \
+                 login`."
                     .to_string(),
             )
         })
@@ -216,18 +233,49 @@ mod tests {
     }
 
     #[test]
+    fn session_id_prefers_a_configured_client_id_over_the_token_claims() {
+        let token = token_with_claims(serde_json::json!({ "azp": "authorized-party" }));
+        assert_eq!(
+            presence_session_id(&token, Some("configured-client".to_string())).unwrap(),
+            "configured-client"
+        );
+    }
+
+    #[test]
+    fn session_id_falls_back_to_the_token_when_the_configured_client_id_is_blank() {
+        let token = token_with_claims(serde_json::json!({ "azp": "authorized-party" }));
+        assert_eq!(
+            presence_session_id(&token, Some("   ".to_string())).unwrap(),
+            "authorized-party"
+        );
+    }
+
+    #[test]
+    fn session_id_accepts_an_opaque_token_when_a_client_id_is_configured() {
+        let mut token = token_with_claims(serde_json::json!({ "azp": "authorized-party" }));
+        token.access_token = "opaque-token".to_string();
+        assert_eq!(
+            presence_session_id(&token, Some("configured-client".to_string())).unwrap(),
+            "configured-client"
+        );
+    }
+
+    #[test]
     fn session_id_prefers_the_authorized_party_claim() {
         let token = token_with_claims(serde_json::json!({
             "azp": "authorized-party",
             "appid": "application-id"
         }));
-        assert_eq!(presence_session_id(&token).unwrap(), "authorized-party");
+        assert_eq!(
+            presence_session_id(&token, None).unwrap(),
+            "authorized-party"
+        );
     }
 
     #[test]
     fn session_id_falls_back_to_the_application_id_claim() {
         let token = token_with_claims(serde_json::json!({ "appid": "application-id" }));
-        assert_eq!(presence_session_id(&token).unwrap(), "application-id");
+        assert_eq!(presence_session_id(&token, None).unwrap(), "application-id");
     }
 
     #[test]
@@ -236,14 +284,14 @@ mod tests {
             "azp": "",
             "appid": "application-id"
         }));
-        assert_eq!(presence_session_id(&token).unwrap(), "application-id");
+        assert_eq!(presence_session_id(&token, None).unwrap(), "application-id");
     }
 
     #[test]
     fn session_id_rejects_blank_application_claims() {
         let token = token_with_claims(serde_json::json!({ "azp": "", "appid": "   " }));
         assert!(matches!(
-            presence_session_id(&token),
+            presence_session_id(&token, None),
             Err(TeamsError::AuthError(_))
         ));
     }
@@ -252,7 +300,7 @@ mod tests {
     fn session_id_rejects_a_token_without_an_application_claim() {
         let token = token_with_claims(serde_json::json!({ "tid": "tenant-id" }));
         assert!(matches!(
-            presence_session_id(&token),
+            presence_session_id(&token, None),
             Err(TeamsError::AuthError(_))
         ));
     }
@@ -262,7 +310,7 @@ mod tests {
         let mut token = token_with_claims(serde_json::json!({ "appid": "application-id" }));
         token.access_token = "not-a-jwt".to_string();
         assert!(matches!(
-            presence_session_id(&token),
+            presence_session_id(&token, None),
             Err(TeamsError::AuthError(_))
         ));
     }

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -3,11 +3,12 @@ use std::time::Instant;
 
 use crate::api::{self, GraphClient};
 use crate::auth;
+use crate::auth::token::TokenInfo;
 use crate::config::ConfigFile;
-use crate::error::Result;
+use crate::error::{Result, TeamsError};
 use crate::models::presence::{
-    DateTimeTimeZone, SetPresenceRequest, SetStatusMessageBody, SetStatusMessageRequest,
-    StatusMessageContent,
+    ClearPresenceRequest, DateTimeTimeZone, SetPresenceRequest, SetStatusMessageBody,
+    SetStatusMessageRequest, StatusMessageContent,
 };
 use crate::output::{self, OutputFormat};
 
@@ -128,7 +129,7 @@ pub async fn run(
         } => {
             let start = Instant::now();
             let req = SetPresenceRequest {
-                session_id: uuid::Uuid::new_v4().to_string(),
+                session_id: presence_session_id(&client.token)?,
                 availability,
                 activity,
                 expiration_duration: expiration,
@@ -161,10 +162,108 @@ pub async fn run(
 
         PresenceCommand::Clear => {
             let start = Instant::now();
-            api::presence::clear_presence(&client).await?;
+            let req = ClearPresenceRequest {
+                session_id: presence_session_id(&client.token)?,
+            };
+            api::presence::clear_presence(&client, &req).await?;
             let result = serde_json::json!({"status": "presence_cleared"});
             output::print_success(format, &result, start);
             Ok(())
         }
+    }
+}
+
+/// Graph identifies a presence session by the application that owns it and expects that
+/// application's ID as `sessionId`. Reading it from the token's own claims keeps `set` and
+/// `clear` on one session regardless of what the profile's configured client ID says now,
+/// and works for a token supplied through `TEAMS_CLI_ACCESS_TOKEN`.
+fn presence_session_id(token: &TokenInfo) -> Result<String> {
+    token
+        .unverified_claims()
+        .and_then(|claims| {
+            [claims.azp, claims.appid]
+                .into_iter()
+                .flatten()
+                .find(|id| !id.trim().is_empty())
+        })
+        .ok_or_else(|| {
+            TeamsError::AuthError(
+                "Access token carries no application ID claim (azp or appid), which Graph \
+                 requires as the presence sessionId. Sign in again with `teams auth login`, or \
+                 check the token in TEAMS_CLI_ACCESS_TOKEN if that is set."
+                    .to_string(),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+    fn token_with_claims(claims: serde_json::Value) -> TokenInfo {
+        TokenInfo {
+            access_token: format!(
+                "header.{}.signature",
+                URL_SAFE_NO_PAD.encode(claims.to_string())
+            ),
+            expires_at: None,
+            token_type: "Bearer".into(),
+            scope: None,
+            refresh_token: None,
+            profile: "default".into(),
+        }
+    }
+
+    #[test]
+    fn session_id_prefers_the_authorized_party_claim() {
+        let token = token_with_claims(serde_json::json!({
+            "azp": "authorized-party",
+            "appid": "application-id"
+        }));
+        assert_eq!(presence_session_id(&token).unwrap(), "authorized-party");
+    }
+
+    #[test]
+    fn session_id_falls_back_to_the_application_id_claim() {
+        let token = token_with_claims(serde_json::json!({ "appid": "application-id" }));
+        assert_eq!(presence_session_id(&token).unwrap(), "application-id");
+    }
+
+    #[test]
+    fn session_id_skips_an_empty_authorized_party_claim() {
+        let token = token_with_claims(serde_json::json!({
+            "azp": "",
+            "appid": "application-id"
+        }));
+        assert_eq!(presence_session_id(&token).unwrap(), "application-id");
+    }
+
+    #[test]
+    fn session_id_rejects_blank_application_claims() {
+        let token = token_with_claims(serde_json::json!({ "azp": "", "appid": "   " }));
+        assert!(matches!(
+            presence_session_id(&token),
+            Err(TeamsError::AuthError(_))
+        ));
+    }
+
+    #[test]
+    fn session_id_rejects_a_token_without_an_application_claim() {
+        let token = token_with_claims(serde_json::json!({ "tid": "tenant-id" }));
+        assert!(matches!(
+            presence_session_id(&token),
+            Err(TeamsError::AuthError(_))
+        ));
+    }
+
+    #[test]
+    fn session_id_rejects_an_undecodable_token() {
+        let mut token = token_with_claims(serde_json::json!({ "appid": "application-id" }));
+        token.access_token = "not-a-jwt".to_string();
+        assert!(matches!(
+            presence_session_id(&token),
+            Err(TeamsError::AuthError(_))
+        ));
     }
 }

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -137,8 +137,12 @@ pub async fn run(
                 activity,
                 expiration_duration: expiration,
             };
+            let session_id = req.session_id.clone();
             api::presence::set_presence(&client, &req).await?;
-            let result = serde_json::json!({"status": "presence_set"});
+            let result = serde_json::json!({
+                "status": "presence_set",
+                "session_id": session_id,
+            });
             output::print_success(format, &result, start);
             Ok(())
         }
@@ -171,8 +175,16 @@ pub async fn run(
                     config::resolve_client_id(None, profile, config),
                 )?,
             };
-            api::presence::clear_presence(&client, &req).await?;
-            let result = serde_json::json!({"status": "presence_cleared"});
+            let session_id = req.session_id.clone();
+            let cleared = api::presence::clear_presence(&client, &req).await?;
+            let result = serde_json::json!({
+                "status": if cleared {
+                    "presence_cleared"
+                } else {
+                    "no_presence_session"
+                },
+                "session_id": session_id,
+            });
             output::print_success(format, &result, start);
             Ok(())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use crate::error::{Result, TeamsError};
 
 pub const OSO_PUBLIC_CLIENT_ID: &str = "fba1b5d0-fdd0-4fe2-9729-9ccdc38f9595";
 pub const DEFAULT_DELEGATED_TENANT_ID: &str = "organizations";
-pub const DEFAULT_DELEGATED_SCOPES: &str = "User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Send Chat.ReadWrite ChatMessage.Send ChatMessage.Read User.ReadBasic.All Presence.Read.All offline_access";
+pub const DEFAULT_DELEGATED_SCOPES: &str = "User.Read Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Send Chat.ReadWrite ChatMessage.Send ChatMessage.Read User.ReadBasic.All Presence.Read.All Presence.ReadWrite offline_access";
 pub const DEFAULT_REDIRECT_URI: &str = "http://localhost:8400/callback";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -487,6 +487,13 @@ scopes = "User.Read People.Read offline_access"
         assert!(DEFAULT_DELEGATED_SCOPES.contains("ChatMessage.Send"));
         assert!(DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Send"));
         assert!(!DEFAULT_DELEGATED_SCOPES.contains("ChannelMessage.Read.All"));
+    }
+
+    #[test]
+    fn default_delegated_scopes_allow_presence_writes() {
+        let scopes: Vec<&str> = DEFAULT_DELEGATED_SCOPES.split_whitespace().collect();
+        assert!(scopes.contains(&"Presence.Read.All"));
+        assert!(scopes.contains(&"Presence.ReadWrite"));
     }
 
     fn config_with_profile_scopes(scopes: Option<&str>) -> ConfigFile {

--- a/src/models/presence.rs
+++ b/src/models/presence.rs
@@ -46,6 +46,13 @@ pub struct SetPresenceRequest {
     pub expiration_duration: Option<String>,
 }
 
+/// Request body for POST /me/presence/clearPresence
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearPresenceRequest {
+    pub session_id: String,
+}
+
 /// Request body for POST /me/presence/setStatusMessage
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -198,5 +205,16 @@ mod tests {
         assert_eq!(p.availability.as_deref(), Some("Available"));
         let serialized = serde_json::to_string(&p).unwrap();
         assert!(serialized.contains("Available"));
+    }
+
+    #[test]
+    fn clear_presence_request_sends_camel_case_session_id() {
+        let req = ClearPresenceRequest {
+            session_id: "app-id".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            serde_json::json!({"sessionId": "app-id"})
+        );
     }
 }


### PR DESCRIPTION
Default delegated logins omitted the permission all three presence-write
commands need. `presence set` and `presence clear` also sent an invalid or
missing `sessionId`. Reproductions and the Graph responses are in #70 and #71.

## Default scopes (#70)

[setPresence], [setStatusMessage] and [clearPresence] all require the delegated
`Presence.ReadWrite` permission, which `DEFAULT_DELEGATED_SCOPES` did not
request. Microsoft does not mark it [admin-consent required][permissions], so it
can join the default set. `docs/auth.md` and `docs/faq.md` now list it with the
rest.

Existing sessions keep the scopes they were granted, so users need to run
`teams auth login` again. `auth refresh` cannot add a scope that was never
consented to. That instruction only reaches logins that take the defaults:
`--scopes`, `TEAMS_CLI_SCOPES` and a profile's `scopes` field replace the
default set rather than extend it, so a login that names its own scopes has to
restate the whole list with `Presence.ReadWrite` in it. `README.md` and
`docs/auth.md` say so.

Deployment follow-up, outside this PR: verify whether the OSO app
registration's static delegated-permission list also needs updating.

## Session ID (#71)

Graph identifies a presence session by the application that owns it, and both
[setPresence] and [clearPresence] document that application's ID as the
`sessionId` they expect. `clearPresence` was sent an empty body; `setPresence`
sent a new random UUID on every invocation.

Both now use a configured client ID — `TEAMS_CLI_CLIENT_ID` or the profile's
`client_id` — when there is one, because that names the application directly
and Microsoft asks callers to treat access tokens as opaque. Otherwise the
value comes from the token's own claims, preferring `azp` and falling back to
`appid`, matching `redeem_refresh_token`'s claim order; that is the path a
login through the built-in application takes, since it configures no client ID.
Blank values are skipped, and a token with no usable application-ID claim and
no configured client ID fails with an auth error rather than a guess. `set` and
`clear` agree either way, because both resolve the value the same way.

## Clearing a session that is not there

Graph answers 404 when the application has no presence session to clear, which
is the state `clear` exists to reach, so a second clear — or a retry after an
ambiguous response — failed against presence that was already automatic. That
answer is no longer an error.

It is not the same outcome as closing a live session: a session opened under a
different application ID answers the same way. `clear` reports which one Graph
gave, `presence_cleared` or `no_presence_session`, and both `set` and `clear`
report the session ID they used, so a `clear` run under different configuration
than the `set` is visible rather than silent. A retry whose earlier attempt
succeeded but lost its response also sees 404, and the prose says so.

## Tests

wiremock asserts the serialized `setPresence` and `clearPresence` payloads, and
covers `clearPresence` answering 404 directly and answering it after a retried
503. Unit tests cover default-scope membership and session-ID selection: a
configured client ID winning over the token, a blank one falling through, an
opaque token accepted when a client ID is configured, and the `azp`/`appid`
order, blank claims and undecodable tokens on the fallback path.

## Not covered

`--expiration` is still passed through without local validation. Presence writes
also do not reject app-only tokens locally, unlike message writes, which call
`require_delegated_token`.

[setPresence]: https://learn.microsoft.com/en-us/graph/api/presence-setpresence
[setStatusMessage]: https://learn.microsoft.com/en-us/graph/api/presence-setstatusmessage
[clearPresence]: https://learn.microsoft.com/en-us/graph/api/presence-clearpresence
[permissions]: https://learn.microsoft.com/en-us/graph/permissions-reference
