### PR TITLE
Fix presence get for a status message with an expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- `teams presence get` no longer fails with `API error (200): Failed to parse API response` when the target's Teams status message carries an expiry. Microsoft Graph sends `statusMessage.expiryDateTime` as a `dateTimeTimeZone` object, not a string, so both `GET /me/presence` and `GET /users/{id}/presence` failed to deserialize for any account with an expiring status message. This resolves #69.
+
+### Added
+
+- `presence get` output now includes `statusMessage.publishedDateTime`, a documented Graph property that was previously discarded during deserialization.
+
 ## v0.4.0 - 2026-08-19
 
 ### Added

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -114,7 +114,10 @@ mod expiry_tests {
             .expect("statusMessage")
             .expiry_date_time
             .expect("expiryDateTime");
-        assert_eq!(expiry.date_time, "2026-09-01T08:00:00.0000000");
-        assert_eq!(expiry.time_zone, "UTC");
+        assert_eq!(
+            expiry.date_time.as_deref(),
+            Some("2026-09-01T08:00:00.0000000")
+        );
+        assert_eq!(expiry.time_zone.as_deref(), Some("UTC"));
     }
 }

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -12,7 +12,11 @@ pub async fn get_my_presence(client: &GraphClient) -> Result<Presence> {
 }
 
 pub async fn get_user_presence(client: &GraphClient, user_id: &str) -> Result<Presence> {
-    client.get(&endpoints::user_presence(user_id), &[]).await
+    get_user_presence_at(client, &endpoints::user_presence(user_id)).await
+}
+
+async fn get_user_presence_at(client: &GraphClient, url: &str) -> Result<Presence> {
+    client.get(url, &[]).await
 }
 
 pub async fn get_presence_batch(client: &GraphClient, ids: Vec<String>) -> Result<Vec<Presence>> {
@@ -37,4 +41,80 @@ pub async fn set_status_message(client: &GraphClient, req: &SetStatusMessageRequ
     client
         .post_no_content(&endpoints::set_status_message(), req)
         .await
+}
+
+#[cfg(test)]
+mod expiry_tests {
+    use super::*;
+    use crate::auth::token::TokenInfo;
+    use crate::config::NetworkConfig;
+    use reqwest::Client;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client() -> GraphClient {
+        GraphClient {
+            http: Client::new(),
+            token: TokenInfo {
+                access_token: "test-token".into(),
+                expires_at: None,
+                token_type: "Bearer".into(),
+                scope: None,
+                refresh_token: None,
+                profile: "default".into(),
+            },
+            network: NetworkConfig {
+                timeout: 30,
+                max_retries: 0,
+                retry_backoff_base: 2,
+            },
+        }
+    }
+
+    /// `/users/{id}/presence` returns the same expiry object as `/me/presence` and failed the same
+    /// way, but it is a distinct call site: a refactor that gave it a response type of its own
+    /// would reintroduce the defect with a fixture test on the shared struct still passing. The
+    /// body is what Graph sends for a user whose status message carries an expiry, the
+    /// `@odata.context` wrapper and `publishedDateTime` included.
+    #[tokio::test]
+    async fn a_user_lookup_parses_a_status_message_expiry() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/user-2/presence"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{
+                    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('user-2')/presence/$entity",
+                    "id": "user-2",
+                    "availability": "Away",
+                    "activity": "Away",
+                    "statusMessage": {
+                        "message": { "content": "Out until Monday", "contentType": "text" },
+                        "publishedDateTime": "2026-08-27T09:14:22.9411568Z",
+                        "expiryDateTime": {
+                            "dateTime": "2026-09-01T08:00:00.0000000",
+                            "timeZone": "UTC"
+                        }
+                    }
+                }"#,
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let presence = get_user_presence_at(
+            &test_client(),
+            &format!("{}/users/user-2/presence", server.uri()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(presence.availability.as_deref(), Some("Away"));
+        let expiry = presence
+            .status_message
+            .expect("statusMessage")
+            .expiry_date_time
+            .expect("expiryDateTime");
+        assert_eq!(expiry.date_time, "2026-09-01T08:00:00.0000000");
+        assert_eq!(expiry.time_zone, "UTC");
+    }
 }

--- a/src/cli/presence.rs
+++ b/src/cli/presence.rs
@@ -6,7 +6,7 @@ use crate::auth;
 use crate::config::ConfigFile;
 use crate::error::Result;
 use crate::models::presence::{
-    SetPresenceRequest, SetStatusExpiry, SetStatusMessageBody, SetStatusMessageRequest,
+    DateTimeTimeZone, SetPresenceRequest, SetStatusMessageBody, SetStatusMessageRequest,
     StatusMessageContent,
 };
 use crate::output::{self, OutputFormat};
@@ -147,9 +147,9 @@ pub async fn run(
                         content: Some(message),
                         content_type: Some("text".to_string()),
                     },
-                    expiry_date_time: expiry.map(|e| SetStatusExpiry {
-                        date_time: e,
-                        time_zone: "UTC".to_string(),
+                    expiry_date_time: expiry.map(|e| DateTimeTimeZone {
+                        date_time: Some(e),
+                        time_zone: Some("UTC".to_string()),
                     }),
                 },
             };

--- a/src/models/presence.rs
+++ b/src/models/presence.rs
@@ -20,7 +20,10 @@ pub struct PresenceStatusMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<StatusMessageContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_date_time: Option<SetStatusExpiry>,
+    pub expiry_date_time: Option<DateTimeTimeZone>,
+    /// Read-only, and Graph sends it only for `GET /me/presence`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_date_time: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,14 +58,20 @@ pub struct SetStatusMessageRequest {
 pub struct SetStatusMessageBody {
     pub message: StatusMessageContent,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_date_time: Option<SetStatusExpiry>,
+    pub expiry_date_time: Option<DateTimeTimeZone>,
 }
 
+/// Microsoft Graph `dateTimeTimeZone`, sent on `setStatusMessage` and returned
+/// by `GET /me/presence`. Both components are optional on the read path: a
+/// response that omits one is worth surfacing as `null` rather than failing the
+/// whole command, which is the defect this type was introduced to fix.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SetStatusExpiry {
-    pub date_time: String,
-    pub time_zone: String,
+pub struct DateTimeTimeZone {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_zone: Option<String>,
 }
 
 /// Request body for batch presence lookup
@@ -95,8 +104,86 @@ mod tests {
             .expect("statusMessage")
             .expiry_date_time
             .expect("expiryDateTime");
-        assert_eq!(expiry.date_time, "9999-12-31T00:00:00.0000000");
-        assert_eq!(expiry.time_zone, "UTC");
+        assert_eq!(
+            expiry.date_time.as_deref(),
+            Some("9999-12-31T00:00:00.0000000")
+        );
+        assert_eq!(expiry.time_zone.as_deref(), Some("UTC"));
+    }
+
+    /// Graph documents `publishedDateTime` on `presenceStatusMessage`, and sends it
+    /// for `GET /me/presence`. It used to be dropped on the floor by serde.
+    #[test]
+    fn presence_keeps_the_status_message_published_date_time() {
+        let json = r#"{
+            "id": "user-1",
+            "availability": "Away",
+            "activity": "Away",
+            "statusMessage": {
+                "message": { "content": "Back on Monday", "contentType": "text" },
+                "publishedDateTime": "2026-08-27T09:14:22.9411568Z"
+            }
+        }"#;
+        let p: Presence = serde_json::from_str(json).unwrap();
+        let status = p.status_message.expect("statusMessage");
+        assert_eq!(
+            status.published_date_time.as_deref(),
+            Some("2026-08-27T09:14:22.9411568Z")
+        );
+        assert!(status.expiry_date_time.is_none());
+        // and it survives back out to the JSON envelope the agent contract promises
+        let out = serde_json::to_value(&status).unwrap();
+        assert_eq!(out["publishedDateTime"], "2026-08-27T09:14:22.9411568Z");
+    }
+
+    /// A response that carries only part of the object still yields a record rather
+    /// than failing the whole command, which is the failure mode #69 was.
+    #[test]
+    fn a_partial_expiry_object_does_not_fail_the_read() {
+        let json = r#"{
+            "statusMessage": { "expiryDateTime": { "dateTime": "2026-09-01T08:00:00.0000000" } }
+        }"#;
+        let p: Presence = serde_json::from_str(json).unwrap();
+        let expiry = p
+            .status_message
+            .expect("statusMessage")
+            .expiry_date_time
+            .expect("expiryDateTime");
+        assert_eq!(
+            expiry.date_time.as_deref(),
+            Some("2026-09-01T08:00:00.0000000")
+        );
+        assert!(expiry.time_zone.is_none());
+    }
+
+    /// The write path is the reason both components exist; optional fields on the
+    /// shared type must not let `setStatusMessage` go out missing one.
+    #[test]
+    fn set_status_message_sends_both_expiry_components() {
+        let req = SetStatusMessageRequest {
+            status_message: SetStatusMessageBody {
+                message: StatusMessageContent {
+                    content: Some("Back on Monday".to_string()),
+                    content_type: Some("text".to_string()),
+                },
+                expiry_date_time: Some(DateTimeTimeZone {
+                    date_time: Some("2026-09-01T08:00:00".to_string()),
+                    time_zone: Some("UTC".to_string()),
+                }),
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            serde_json::json!({
+                "statusMessage": {
+                    "message": { "content": "Back on Monday", "contentType": "text" },
+                    "expiryDateTime": {
+                        "dateTime": "2026-09-01T08:00:00",
+                        "timeZone": "UTC"
+                    }
+                }
+            })
+        );
     }
 
     #[test]

--- a/src/models/presence.rs
+++ b/src/models/presence.rs
@@ -20,7 +20,7 @@ pub struct PresenceStatusMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<StatusMessageContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expiry_date_time: Option<String>,
+    pub expiry_date_time: Option<SetStatusExpiry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,7 +58,7 @@ pub struct SetStatusMessageBody {
     pub expiry_date_time: Option<SetStatusExpiry>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetStatusExpiry {
     pub date_time: String,
@@ -74,6 +74,30 @@ pub struct GetPresenceBatchRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn presence_parses_an_object_valued_status_message_expiry() {
+        let json = r#"{
+            "id": "user-1",
+            "availability": "Available",
+            "activity": "Available",
+            "statusMessage": {
+                "message": { "content": "Back on Monday", "contentType": "text" },
+                "expiryDateTime": {
+                    "dateTime": "9999-12-31T00:00:00.0000000",
+                    "timeZone": "UTC"
+                }
+            }
+        }"#;
+        let p: Presence = serde_json::from_str(json).unwrap();
+        let expiry = p
+            .status_message
+            .expect("statusMessage")
+            .expiry_date_time
+            .expect("expiryDateTime");
+        assert_eq!(expiry.date_time, "9999-12-31T00:00:00.0000000");
+        assert_eq!(expiry.time_zone, "UTC");
+    }
 
     #[test]
     fn presence_serde_round_trip() {


### PR DESCRIPTION
`teams presence get` failed for any account whose Teams status message carries
an expiry. The HTTP call succeeded; deserialization did not.

`GET /me/presence` returns `statusMessage.expiryDateTime` as a
[dateTimeTimeZone](https://learn.microsoft.com/en-us/graph/api/resources/datetimetimezone)
object:

```json
"expiryDateTime": { "dateTime": "9999-12-31T00:00:00.0000000", "timeZone": "UTC" }
```

`PresenceStatusMessage::expiry_date_time` was typed `Option<String>`, so serde
rejected the body and the command reported `API error (200)`. The write path
already models that shape as `SetStatusExpiry`, which now derives `Deserialize`
and serves both directions.

## Which read paths this affects

`get_my_presence`, `get_user_presence` and `get_presence_batch` all
deserialize into the same `Presence` struct, so the failure is data-dependent
rather than path-dependent: any of them breaks the moment the response
actually carries the field.

Two of the three do. Measured against one build, one profile, one minute:

| Call | Result | Why |
|---|---|---|
| `presence get` (`/me/presence`) | fails to parse | target has a status message carrying an expiry |
| `presence get --user <id>` | fails to parse | same struct, same expiry |
| `presence get --user <other-id>` | succeeds | that account has no status message, so no expiry to mistype |
| `presence get-batch --user-ids <both>` | succeeds | the batch response omits `expiryDateTime` entirely |

`get-batch` is unaffected because `POST /communications/getPresencesByUserId`
does not return the field, not because it parses a different shape. It
returned the same account's `statusMessage.message` with content and
`contentType` and no `expiryDateTime` alongside it.

So the corrected statement is that `/me/presence` and `/users/{id}/presence`
are both affected, for any target whose status message carries an expiry.
A single-user lookup is the call an agent makes most often when checking
whether a colleague is free, so it is worth being precise about.

## Tests

The pre-existing round-trip test passed only because its fixture sets
`statusMessage` to null.

Two tests now cover a status message with an expiry. One parses a
`/me/presence` body. The other serves a `/users/{id}/presence` body over a
mock and reads it back through `get_user_presence_at`, the seam
`get_user_presence` delegates to, with the `@odata.context` wrapper and
`publishedDateTime` that Graph actually sends, following the pattern the
message and channel modules already use. Going through the call rather than
parsing a string is what makes it a guard on that path: a refactor giving the
user lookup a response type of its own would otherwise reintroduce the defect
with a fixture test on the shared struct still passing.

Reverting the type change fails both.

Note for whoever merges: #72 also appends a test module to
`src/api/presence.rs`, so whichever of the two lands second needs a trivial
conflict resolved there.

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C736oc7CeNtRZmAJrXm8sG
