### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## v0.5.0 - 2026-08-30
+
+### Added
+
+- `teams message send --mention USER` (repeatable) tags a person with a real Teams @mention, in chats and channels. Graph only keeps a mention when the body's `<at id="N">` elements are synchronized with a top-level `mentions` array, so the CLI builds both: each value (Entra object ID or UPN) is resolved through Graph, display names are HTML-escaped into the `<at>` prefix in flag order, duplicates collapse to one mention, and a plain-text body is promoted to HTML safely. A mention on its own counts as a body. Raw `<at>` markup in an HTML body without `--mention` is rejected before anything is sent, and `message list`/`get` retain any mentions Graph returns.
+- `presence get` output now includes `statusMessage.publishedDateTime`, a documented Graph property that was previously discarded during deserialization.
+- `teams auth list` reports, for each profile, the signed-in `user`, `tenant_id`, and `auth_type` (`delegated`, `app-only`, or `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`, without any network call. A profile whose token cannot be read or decoded is still listed with those fields `null`. This resolves #54.
+
 ### Changed
 
 - Refreshed the Rust dependencies: the rust-minor group (clap, clap_complete and others), `base64` 0.22 → 0.23, `toml` 0.8 → 1.1, and `comfy-table` 7.2 → 8.0. comfy-table 8 turns the presets into `TableStyle` constants and replaces `Table::load_preset` with `Table::load_style`; table rendering is unchanged.
@@ -20,14 +28,6 @@
 - `teams presence get` no longer fails with `API error (200): Failed to parse API response` when the target's Teams status message carries an expiry. Microsoft Graph sends `statusMessage.expiryDateTime` as a `dateTimeTimeZone` object, not a string, so both `GET /me/presence` and `GET /users/{id}/presence` failed to deserialize for any account with an expiring status message. This resolves #69.
 - On Windows, `teams auth login` no longer fails with `KEYRING_ERROR: ... longer than platform limit of 2560 chars` after a successful sign-in. Credential Manager caps a credential at 2560 bytes and a Microsoft Graph token bundle is routinely larger, so the serialized token is now split across `<profile>:token:<n>` entries with a `<profile>:token` header; `auth logout` removes every piece. macOS and Linux keep a single keychain item as before. This resolves #67.
 - `teams auth logout` now reports a failure to delete the stored token instead of silently succeeding and leaving it in the keyring. A profile with no stored token still logs out cleanly.
-
-### Added
-
-- `teams message send --mention USER` (repeatable) tags a person with a real Teams @mention, in chats and channels. Graph only keeps a mention when the body's `<at id="N">` elements are synchronized with a top-level `mentions` array, so the CLI builds both: each value (Entra object ID or UPN) is resolved through Graph, display names are HTML-escaped into the `<at>` prefix in flag order, duplicates collapse to one mention, and a plain-text body is promoted to HTML safely. A mention on its own counts as a body. Raw `<at>` markup in an HTML body without `--mention` is rejected before anything is sent, and `message list`/`get` retain any mentions Graph returns.
-
-- `presence get` output now includes `statusMessage.publishedDateTime`, a documented Graph property that was previously discarded during deserialization.
-- `teams auth list` reports, for each profile, the signed-in `user`, `tenant_id`, and `auth_type` (`delegated`, `app-only`, or `unknown`) decoded from the stored token's claims, plus the stored token's `expires_at`, without any network call. A profile whose token cannot be read or decoded is still listed with those fields `null`. This resolves #54.
-
 ## v0.4.0 - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
Cuts v0.5.0 from the issue/PR sweep that closed #54, #67, #69, #70, #71, #79, #80, #81 and #85, plus the dependency refresh.

Minor bump rather than patch: it adds `message send --mention` and changes the `auth list` output contract (`profiles` is now an array of objects, not names).

## Release gate

| Check | Result |
| --- | --- |
| `cargo fmt -- --check` | pass |
| `cargo check --all-targets --all-features` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo test --all-targets --all-features` | 231 unit + 67 CLI, 0 failed |
| `cargo build --release --locked` | pass |
| `cargo audit` | exit 0 (1 allowed `unsound` warning, RUSTSEC-2026-0097 `rand` via `quinn`/`reqwest`, transitive and unchanged from v0.4.0) |
| `mandoc -Tlint` | one pre-existing STYLE warning, byte-identical on the v0.4.0 tag |
| `git diff --check` | pass |

## Live validation against a real tenant

Run with the 0.5.0 release binary on a delegated session whose token predates the scope change:

- `auth status`, `auth list`, `user me`, `team list`, `chat list`, `presence get` — all succeed.
- **#80** — `presence set` returned Graph's `Forbidden` with a literally empty `message`, and the CLI appended the hint listing the nine scopes the token holds, with `Presence.ReadWrite` visibly absent. Exit 4.
- **#81** — `--expiration 1h` rejected locally, exit 2, before any network call. An undocumented availability/activity pair is still left to Graph rather than blocked locally, as intended.
- **#78** — a mention posted to the validation sandbox chat came back with `<at id="0">Keito</at>` in the body and a synchronized `mentions[0].id: 0` carrying the resolved object ID, so Graph kept it.
- **#85 / #86** — a card posted with no `--body` at all (previously rejected outright) and Graph accepted the marker; a `--content-type text` body containing `<` and `&` came back as `<p>a &lt; b &amp; "c"</p>` with `contentType: html`.

The presence *write* path could not be exercised end to end because the available session predates `Presence.ReadWrite` — which is the situation the CHANGELOG tells users to resolve with `teams auth login`. It is covered by wiremock tests, and the 403 above confirms the scope gap is diagnosed correctly.