### PR TITLE
Release v0.6.0: emit the command tree as JSON and notify the docs site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,3 +225,27 @@ jobs:
           repository: osodevops/scoop-bucket
           event-type: update-teams-manifest
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "tag": "${{ github.ref_name }}"}'
+
+  notify-docs:
+    name: Notify Documentation Site
+    needs: release
+    runs-on: ubuntu-latest
+    permissions: {}
+    # Never fail a published release over a docs notification. The docs repo also
+    # regenerates on a weekly schedule, so a missed dispatch delays the reference
+    # rather than losing it.
+    continue-on-error: true
+    steps:
+      # ms-teams-cli-docs regenerates reference/command/** from `teams --help-json`
+      # on the released binary, and its sidebar version badge is resolved at build
+      # time. Without this dispatch neither ever fires on a release: the docs repo
+      # listens for `cli-released` and nothing was sending it.
+      - name: Trigger docs regeneration and redeploy
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          # Prefers a purpose-scoped secret; falls back to the token already used
+          # to dispatch across org repositories so this works before one is added.
+          token: ${{ secrets.DOCS_DISPATCH_TOKEN || secrets.HOMEBREW_TAP_TOKEN }}
+          repository: osodevops/ms-teams-cli-docs
+          event-type: cli-released
+          client-payload: '{"tag": "${{ github.ref_name }}", "repo": "${{ github.repository }}"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.6.0 - 2026-08-30
+
+### Added
+
+- `teams --help-json` emits the whole command tree as JSON: every command's path, summary, usage, and command-specific flags with their value names, defaults, environment variables, and whether they are required. This is what the documentation site consumes to regenerate its command reference on each release. Global options and clap's synthesised `help` subcommands are excluded, since the reference documents globals once and the `help` entries are not part of the command surface.
+
+### Fixed
+
+- The documentation site's command reference can regenerate again. Its workflow has always called `teams --help-json`, which did not exist, so every scheduled run since at least 2026-07-06 failed and `reference/command/**` stayed frozen at v0.3.0. A release now also notifies the docs repository, which previously received no `cli-released` event at all, so the reference and the site's version badge both refresh on release.
+
 ## v0.5.0 - 2026-08-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/src/help_json.rs
+++ b/src/help_json.rs
@@ -1,0 +1,360 @@
+//! Machine-readable dump of the command tree, for the documentation site.
+//!
+//! `teams --help-json` emits the whole clap command tree as JSON so
+//! `ms-teams-cli-docs` can regenerate its command reference on each release
+//! instead of hand-maintaining ~190 pages. The shape is the contract that
+//! `docs/scripts/render-cli-reference.mjs` consumes; changing a field name
+//! here breaks that renderer.
+//!
+//! `examples` and `exit_codes` are emitted empty on purpose. They are prose
+//! rather than anything clap knows, so they are curated on the docs side and
+//! merged in by command path when the reference is rendered.
+
+use clap::{Arg, Command};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct HelpJson {
+    pub version: String,
+    pub binary: String,
+    pub description: String,
+    pub commands: Vec<CommandJson>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommandJson {
+    pub name: String,
+    pub path: Vec<String>,
+    pub summary: String,
+    pub description: String,
+    pub usage: String,
+    pub flags: Vec<FlagJson>,
+    pub examples: Vec<serde_json::Value>,
+    pub exit_codes: Vec<serde_json::Value>,
+    pub subcommands: Vec<CommandJson>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FlagJson {
+    pub name: String,
+    pub description: String,
+    pub alias: Option<String>,
+    pub value_name: Option<String>,
+    pub required: bool,
+    pub env: Option<String>,
+    pub default: Option<String>,
+}
+
+/// Render the tree rooted at `cmd`.
+pub fn build(mut cmd: Command) -> HelpJson {
+    // Populate propagated globals and generated help/version args, so the
+    // filtering below sees the same argument set a real parse would.
+    cmd.build();
+
+    let description = cmd
+        .get_about()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "Microsoft Teams CLI".to_string());
+
+    let commands = cmd
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
+        .map(|sub| command_json(sub, &[]))
+        .collect();
+
+    HelpJson {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        binary: cmd.get_name().to_string(),
+        description,
+        commands,
+    }
+}
+
+fn command_json(cmd: &Command, parents: &[String]) -> CommandJson {
+    let name = cmd.get_name().to_string();
+    let mut path = parents.to_vec();
+    path.push(name.clone());
+
+    let summary = cmd.get_about().map(|s| s.to_string()).unwrap_or_default();
+    let description = cmd
+        .get_long_about()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| summary.clone());
+
+    let subcommands = cmd
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
+        .map(|sub| command_json(sub, &path))
+        .collect();
+
+    CommandJson {
+        name,
+        summary,
+        description,
+        usage: usage_for(cmd, &path),
+        flags: cmd.get_arguments().filter_map(flag_json).collect(),
+        examples: Vec::new(),
+        exit_codes: Vec::new(),
+        subcommands,
+        path,
+    }
+}
+
+/// `teams auth login [OPTIONS] --device-code`, without clap's leading
+/// "Usage: ". clap already renders the full command path, so it is used as
+/// given; the full path is only a fallback for a command that renders none.
+fn usage_for(cmd: &Command, path: &[String]) -> String {
+    let rendered = cmd.clone().render_usage().to_string();
+    let line = rendered
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let line = line
+        .strip_prefix("Usage:")
+        .unwrap_or(&line)
+        .trim()
+        .to_string();
+
+    if line.is_empty() {
+        format!("teams {}", path.join(" "))
+    } else {
+        line
+    }
+}
+
+/// Command-specific options only. Globals are documented once in the
+/// reference's "Global Options" table, and `help`/`version` are clap's own.
+fn flag_json(arg: &Arg) -> Option<FlagJson> {
+    if arg.is_global_set() {
+        return None;
+    }
+    let id = arg.get_id().as_str();
+    if id == "help" || id == "version" {
+        return None;
+    }
+    if arg.is_hide_set() {
+        return None;
+    }
+
+    let long = arg.get_long().map(|l| format!("--{l}"));
+    let short = arg.get_short().map(|s| format!("-{s}"));
+    // A positional has neither; name it by its value placeholder.
+    let name = long
+        .clone()
+        .or_else(|| short.clone())
+        .unwrap_or_else(|| id.to_uppercase());
+
+    let value_name = arg
+        .get_value_names()
+        .and_then(|names| names.first().map(|n| n.to_string()));
+
+    let default = {
+        let defaults = arg.get_default_values();
+        if defaults.is_empty() {
+            None
+        } else {
+            Some(
+                defaults
+                    .iter()
+                    .map(|v| v.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        }
+    };
+
+    Some(FlagJson {
+        // When both forms exist the long one is the name and the short is the alias,
+        // which is the order the renderer prints them in.
+        alias: if long.is_some() { short } else { None },
+        name,
+        description: arg
+            .get_help()
+            .map(|h| h.to_string())
+            .unwrap_or_default()
+            .replace('\n', " "),
+        value_name,
+        required: arg.is_required_set(),
+        env: arg
+            .get_env()
+            .map(|e| e.to_string_lossy().into_owned())
+            .filter(|e| !e.is_empty()),
+        default,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Cli;
+    use clap::CommandFactory;
+
+    fn tree() -> HelpJson {
+        build(Cli::command())
+    }
+
+    fn find<'a>(commands: &'a [CommandJson], path: &[&str]) -> &'a CommandJson {
+        let (head, rest) = path.split_first().expect("non-empty path");
+        let found = commands
+            .iter()
+            .find(|c| c.name == *head)
+            .unwrap_or_else(|| panic!("no command {head}"));
+        if rest.is_empty() {
+            found
+        } else {
+            find(&found.subcommands, rest)
+        }
+    }
+
+    #[test]
+    fn the_tree_carries_the_crate_version_and_binary_name() {
+        let tree = tree();
+        assert_eq!(tree.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(tree.binary, "teams");
+        assert!(!tree.description.is_empty());
+        assert!(tree.commands.len() > 10, "{}", tree.commands.len());
+    }
+
+    #[test]
+    fn nested_commands_carry_their_full_path() {
+        let tree = tree();
+        let login = find(&tree.commands, &["auth", "login"]);
+        assert_eq!(login.path, vec!["auth", "login"]);
+        assert!(
+            login.usage.starts_with("teams auth login"),
+            "{}",
+            login.usage
+        );
+    }
+
+    /// The renderer prints globals once in its own table, so a command's flag
+    /// list must not repeat them — otherwise every one of ~190 pages grows a
+    /// duplicate `--output`/`--profile` block.
+    #[test]
+    fn global_options_are_not_repeated_on_every_command() {
+        let tree = tree();
+        let send = find(&tree.commands, &["message", "send"]);
+        let names: Vec<&str> = send.flags.iter().map(|f| f.name.as_str()).collect();
+        for global in ["--output", "--profile", "--quiet", "--help", "--version"] {
+            assert!(!names.contains(&global), "{global} leaked into {names:?}");
+        }
+        assert!(names.contains(&"--body"), "{names:?}");
+    }
+
+    /// These are the fields this release actually added; if the emitter ever
+    /// stops reporting them the docs silently lose the new surface.
+    #[test]
+    fn newly_added_flags_reach_the_dump() {
+        let commands = tree().commands;
+        let send = find(&commands, &["message", "send"]);
+        let mention = send
+            .flags
+            .iter()
+            .find(|f| f.name == "--mention")
+            .expect("--mention");
+        assert_eq!(mention.value_name.as_deref(), Some("USER"));
+        assert!(!mention.required);
+
+        let set = find(&commands, &["presence", "set"]);
+        let availability = set
+            .flags
+            .iter()
+            .find(|f| f.name == "--availability")
+            .expect("--availability");
+        assert!(availability.required, "availability is a required option");
+        assert!(
+            availability.description.contains("Available"),
+            "{}",
+            availability.description
+        );
+    }
+
+    #[test]
+    fn a_flag_with_an_env_var_reports_it() {
+        // --profile is global, so reach for a command-level env-backed flag via the
+        // root's own argument list instead.
+        let mut root = Cli::command();
+        root.build();
+        let profile = root
+            .get_arguments()
+            .find(|a| a.get_id() == "profile")
+            .expect("profile arg");
+        assert_eq!(
+            profile
+                .get_env()
+                .map(|e| e.to_string_lossy().into_owned())
+                .as_deref(),
+            Some("TEAMS_CLI_PROFILE")
+        );
+    }
+
+    /// clap synthesises a `help` subcommand under every parent. Including them
+    /// tripled the command count and would have produced ~280 junk pages.
+    #[test]
+    fn synthesised_help_subcommands_are_excluded() {
+        fn walk(commands: &[CommandJson], found: &mut Vec<String>) {
+            for c in commands {
+                if c.name == "help" {
+                    found.push(c.path.join(" "));
+                }
+                walk(&c.subcommands, found);
+            }
+        }
+        let tree = tree();
+        let mut found = Vec::new();
+        walk(&tree.commands, &mut found);
+        assert!(found.is_empty(), "help subcommands leaked: {found:?}");
+    }
+
+    /// clap renders the full path already; splicing it in again produced
+    /// "teams message send message send [OPTIONS]".
+    #[test]
+    fn usage_states_the_command_path_exactly_once() {
+        let tree = tree();
+        let send = find(&tree.commands, &["message", "send"]);
+        assert_eq!(
+            send.usage.matches("message send").count(),
+            1,
+            "{}",
+            send.usage
+        );
+        assert!(
+            send.usage.starts_with("teams message send"),
+            "{}",
+            send.usage
+        );
+    }
+
+    /// The docs renderer curates these itself and merges them by path.
+    #[test]
+    fn examples_and_exit_codes_are_left_for_the_docs_to_supply() {
+        let tree = tree();
+        let login = find(&tree.commands, &["auth", "login"]);
+        assert!(login.examples.is_empty());
+        assert!(login.exit_codes.is_empty());
+    }
+
+    #[test]
+    fn the_dump_serializes_to_the_shape_the_renderer_expects() {
+        let value = serde_json::to_value(tree()).unwrap();
+        for key in ["version", "binary", "description", "commands"] {
+            assert!(value.get(key).is_some(), "missing {key}");
+        }
+        let first = &value["commands"][0];
+        for key in [
+            "name",
+            "path",
+            "summary",
+            "description",
+            "usage",
+            "flags",
+            "examples",
+            "exit_codes",
+            "subcommands",
+        ] {
+            assert!(first.get(key).is_some(), "command missing {key}");
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@ mod auth;
 mod cli;
 mod config;
 mod error;
+mod help_json;
 mod listen;
 mod models;
 mod output;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::Cli;
@@ -15,6 +16,21 @@ use crate::output::OutputFormat;
 
 #[tokio::main]
 async fn main() {
+    // Handled before clap parses, because the root requires a subcommand and
+    // `teams --help-json` deliberately has none. The docs site calls this on the
+    // released binary to regenerate its command reference.
+    if std::env::args_os().any(|arg| arg == "--help-json") {
+        let dump = help_json::build(Cli::command());
+        match serde_json::to_string_pretty(&dump) {
+            Ok(json) => output::write_stdout_line(&json),
+            Err(e) => {
+                eprintln!("Failed to render help JSON: {e}");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
     let cli = Cli::parse();
 
     let output_format_flag = cli.output.clone();


### PR DESCRIPTION
Unblocks the documentation site's command reference, which has been frozen at **v0.3.0**.

## What was broken

Two independent faults, both confirmed during the v0.5.0 release:

1. `ms-teams-cli-docs` regenerates `reference/command/**` by running `teams --help-json` on the released binary. **That flag never existed** (`error: unexpected argument '--help-json' found`), so every scheduled run since at least 2026-07-06 failed.
2. The docs repo listens for a `cli-released` repository dispatch. **Nothing ever sent one** — `release.yml` dispatched only to homebrew-tap and scoop-bucket. So a release triggered neither the regeneration nor the rebuild that refreshes the site's version badge, which is resolved at build time.

Consequently the published reference still has no `--mention`, still shows `--expiration ISO8601` with no range or valid pairs, and still describes `auth list` as "List all authenticated profiles".

## `--help-json`

Walks the clap command tree and emits the shape `docs/scripts/render-cli-reference.mjs` consumes. Handled before clap parses, because the root requires a subcommand and this deliberately has none.

Two things are excluded, each with a test:

- **Global options**, because the reference documents them once in its own table; without the filter every one of ~190 pages would grow a duplicate `--output`/`--profile` block.
- **clap's synthesised `help` subcommands**, which are not part of the command surface. Including them took the tree from 122 commands to 401 and would have produced ~280 junk pages.

`examples` and `exit_codes` are emitted empty by design — they are prose, not something clap knows, so they stay curated on the docs side and are merged back by command path there ([docs#10](https://github.com/osodevops/ms-teams-cli-docs/pull/10), already merged, so the first regeneration keeps all nine curated example sets).

Verified against the docs renderer: 122 commands, identical to the current bootstrap, none added or removed.

## notify-docs

Sends `cli-released` after the release publishes. It is `continue-on-error` — a docs notification must never fail a published release — and the docs repo still regenerates weekly, so a missed dispatch delays the reference rather than losing it. The token prefers a purpose-scoped `DOCS_DISPATCH_TOKEN` and falls back to the token already used to dispatch across org repositories, so it works before one is created.

## Gate

`fmt`, `clippy -D warnings`, **240 unit + 67 CLI tests**, `build --release --locked`, `git diff --check` all pass. `mandoc` reports the one pre-existing STYLE warning, byte-identical on the v0.4.0 tag.