### PR TITLE
Reserve an 8 MiB main-thread stack on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Windows builds reserve an 8 MiB main-thread stack, matching Linux and macOS. Windows gives the main thread 1 MiB by default, and building clap's command tree for this many subcommands needs almost all of it in an unoptimized build, so any addition to the `message` command made every debug and test invocation of `teams` on Windows — `--help` included — fail with `thread 'main' has overflowed its stack`, and `cargo test` failed on `windows-latest` while passing on Linux and macOS. A build script now passes `/STACK:8388608` to the MSVC linker (`--stack` on the GNU toolchain). The reservation is address space rather than committed memory, so an idle process costs nothing extra.
+
 ## v0.6.0 - 2026-08-30
 
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+//! Windows reserves 1 MiB of stack for the main thread; Linux and macOS give
+//! it 8 MiB. Building clap's command tree for this many subcommands uses
+//! almost all of that 1 MiB in an unoptimized build (measured at just under
+//! it on 2026-09-06), so on Windows every debug or test invocation of `teams`
+//! — `--help` included — overflowed the stack as soon as one more flag was
+//! added to `message`, and `cargo test` failed there while passing elsewhere.
+//!
+//! Reserving the same 8 MiB the Unix targets get removes the cliff. It is
+//! address space, not committed memory, so an idle process costs nothing
+//! extra. rustup does the same for the same reason (clap's debug-mode stack
+//! use, clap-rs/clap#5134). A build script survives CI overriding `RUSTFLAGS`, which a
+//! `.cargo/config.toml` `rustflags` entry would not.
+
+use std::env;
+
+const MAIN_THREAD_STACK_BYTES: u32 = 8 * 1024 * 1024;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+    match env::var("CARGO_CFG_TARGET_ENV").as_deref() {
+        Ok("msvc") => println!("cargo:rustc-link-arg=/STACK:{MAIN_THREAD_STACK_BYTES}"),
+        Ok("gnu") => println!("cargo:rustc-link-arg=-Wl,--stack,{MAIN_THREAD_STACK_BYTES}"),
+        _ => {}
+    }
+}


### PR DESCRIPTION
## Problem

Windows gives the main thread 1 MiB of stack; Linux and macOS give it 8 MiB. Building clap's derived command tree for this many subcommands needs just under 1 MiB in an unoptimized build, so `main` is already at the edge: adding one flag to `message` (#90, #91) made **every** debug and test invocation of `teams` on Windows, `--help` included, fail with

```
thread 'main' has overflowed its stack
```

and `cargo test --all-targets` failed on `windows-latest` only (both PRs' CI runs), while #92 and #93, which do not touch `message`, passed.

Measured locally with `ulimit -s`: `main`, #90 and #91 all fail below 1024 KiB on macOS as well, in every startup phase including `--help-json`, which only builds the command tree.

## Fix

A `build.rs` passes `/STACK:8388608` to the MSVC linker (`--stack` on the GNU toolchain) for Windows targets, which matches the Unix defaults. This is what rustup does for the same clap behaviour (clap-rs/clap#5134). A build script survives CI overriding `RUSTFLAGS`, which a `.cargo/config.toml` `rustflags` entry would not. The reservation is address space, not committed memory.

## Verification

`main` passes on Windows with or without this change, so the proof is #90: it is rebased onto this branch and its `windows-latest` job goes green with the same code that failed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WG7vFLjFZHqAUMRS1zkWRE