### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.0 - 2026-09-06
+
 ### Added
 
 - `teams message send --subject TEXT` sets the subject line on a channel root message — the bold title Teams renders above the body, the same field the client offers behind "Add a subject". Channel sends only: chat messages have no subject, so `--subject` with `--chat` (or without `--channel`) is rejected as invalid input before anything is sent.
@@ -19,7 +21,6 @@
 - Plain lists retain optional fields that first appear after the first row, including message subjects. Human message lists include a Subject column; JSON still omits absent subjects.
 - `message list` and `message get` no longer drop the `subject` of a message. The `ChatMessage` model had no `subject` field, so a channel root message's subject — returned by Graph on both reads — silently vanished from every output: a message posted with a subject read back without one. Messages without a subject are unchanged and gain no `"subject": null` noise.
 - `teams message send --chat … --attach FILE` now shares each uploaded file with the chat's other members. The upload lands in the sender's OneDrive (`Microsoft Teams Chat Files`), where nobody else has access; the Teams client grants every member read permission when it attaches a file, but the CLI did not, so recipients got "you don't have permission" when they opened the attachment. After each upload the CLI now grants the members read access through the drive item's `invite` action, with no notification email. A member is addressed by Entra object ID only when the roster shows the same tenant as the sender — Graph documents that a chat's membership can span tenants, and an object ID means nothing outside its own directory — and by email otherwise; the sender is skipped. Every step is best-effort: a failed member lookup, a member with no usable address, or a refused grant warns on stderr and says to share the file from OneDrive by hand, and the upload and the message still go through. Channel attachments are unchanged: they live in the team's SharePoint library, which channel members already read.
-
 
 ## v0.6.0 - 2026-08-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "teams-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teams-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/docs/man/teams.1
+++ b/docs/man/teams.1
@@ -104,7 +104,8 @@ It tries exact user lookup, People API search when
 .B People.Read
 is available (verified back to
 .B /users/{userPrincipalName}
-before returning an object ID), then a bounded shared-chat roster sweep. JSON candidates include
+before returning an object ID), then a bounded shared-chat roster sweep. JSON
+candidates include
 .B via
 and a per-stage report so callers can see which lookup paths were used. No
 candidates exits with code 5.


### PR DESCRIPTION
Cuts v0.7.0 with everything merged since v0.6.0 (#89–#94).

### Added
- `message send --subject` on channel root messages (#90)
- `message list --message-id ROOT` to list a channel thread's replies (#91)
- `message reply --mention` (#91)
- `presence set-preferred` / `presence clear-preferred` (#92)

### Changed
- uuid 1.26.0, rand 0.9.3 (clears RUSTSEC-2026-0097)

### Fixed
- Windows 8 MiB main-thread stack (#94)
- Plain lists keep optional fields; human message lists gain a Subject column; `message list`/`get` keep `subject` (#90)
- Chat attachments are shared with the chat's members after upload (#93)

### Release checklist
- [x] `Cargo.toml` and root `Cargo.lock` entry bumped to 0.7.0
- [x] CHANGELOG "Unreleased" turned into `## v0.7.0 - 2026-09-06`, empty Unreleased kept
- [x] fmt / check / clippy `-D warnings` / test (267 unit + 78 integration) / `build --release --locked` / `cargo audit` / `git diff --check` all pass locally
- [x] `mandoc -Tlint` clean (one over-long text line wrapped; rendering unchanged)
- [x] Live smoke with the release binary against the self-only sandbox chat: `auth doctor`, `user me`, `chat list`, `message send`, `message list` (subject retained in JSON, Subject column in plain output), `presence get`; `--subject` with `--chat` rejected locally with exit 2; `presence set-preferred` without `Presence.ReadWrite` returns the 403 scope hint

Merging triggers `auto-tag.yml` → `v0.7.0` → `release.yml` (5 builds, GitHub release, Homebrew tap, Scoop bucket, docs `cli-released` dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
